### PR TITLE
Fix poe.ninja price not matching the linked sockets

### DIFF
--- a/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
@@ -363,11 +363,10 @@ namespace Sidekick.Apis.Poe.Trade
         private static void SetSocketFilters(Item item, SearchFilters filters)
         {
             // Auto Search 5+ Links
-            var highestCount = item.Sockets
-                .GroupBy(x => x.Group)
-                .Select(x => x.Count())
-                .OrderByDescending(x => x)
-                .FirstOrDefault();
+            var highestCount = item.Sockets.GroupBy(x => x.Group)
+                                           .Select(x => x.Count())
+                                           .Max();
+
             if (highestCount >= 5)
             {
                 filters.SocketFilters.Filters.Links = new SocketFilterOption()

--- a/src/Sidekick.Apis.PoeNinja/Api/Models/PoeNinjaItem.cs
+++ b/src/Sidekick.Apis.PoeNinja/Api/Models/PoeNinjaItem.cs
@@ -21,7 +21,7 @@ namespace Sidekick.Apis.PoeNinja.Api.Models
 
         //public string ArtFilename { get; set; }
 
-        //public int Links { get; set; }
+        public int Links { get; set; }
 
         public int ItemClass { get; set; }
 

--- a/src/Sidekick.Apis.PoeNinja/Api/PoeNinjaApiClient.cs
+++ b/src/Sidekick.Apis.PoeNinja/Api/PoeNinjaApiClient.cs
@@ -124,7 +124,8 @@ namespace Sidekick.Apis.PoeNinja.Api
                             DetailsId = x.DetailsId,
                             ItemType = itemType,
                             SparkLine = x.SparkLine ?? x.LowConfidenceSparkLine,
-                            IsRelic = x.ItemClass == 9 // 3 for Unique, 9 for Relic Unique.
+                            IsRelic = x.ItemClass == 9, // 3 for Unique, 9 for Relic Unique.
+                            Links = x.Links,
                         })
                         .ToList(),
                     result.Language.Translations

--- a/src/Sidekick.Apis.PoeNinja/Models/NinjaPrice.cs
+++ b/src/Sidekick.Apis.PoeNinja/Models/NinjaPrice.cs
@@ -45,5 +45,6 @@ namespace Sidekick.Apis.PoeNinja.Models
         public SparkLine SparkLine { get; set; }
 
         public bool IsRelic { get; set; }
+        public int Links { get; set; }
     }
 }

--- a/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
@@ -114,12 +114,17 @@ namespace Sidekick.Apis.PoeNinja
                                           && x.MapTier == item.Properties.MapTier
                                           && x.GemLevel == item.Properties.GemLevel
                                           && x.IsRelic == item.Properties.IsRelic);
+
+                    // Poe.ninja has pricings for <5, 5 and 6 links.
+                    // <5 being 0 links in their API.
+                    var highestSocketLinks = item.Sockets.GroupBy(x => x.Group)
+                                                         .Select(x => x.Count())
+                                                         .Max();
+
+                    query = query.Where(x => x.Links == (highestSocketLinks >= 5 ? highestSocketLinks : 0));
                 }
 
-                if (query.Any())
-                {
-                    return query.FirstOrDefault();
-                }
+                return query.FirstOrDefault();
             }
 
             return null;

--- a/src/Sidekick.Apis.PoeNinja/Repository/PoeNinjaRepository.cs
+++ b/src/Sidekick.Apis.PoeNinja/Repository/PoeNinjaRepository.cs
@@ -35,7 +35,11 @@ namespace Sidekick.Apis.PoeNinja.Repository
         public Task SavePrices(ItemType itemType, List<NinjaPrice> prices)
         {
             prices = prices
-                .GroupBy(x => (x.Name, x.Corrupted, x.MapTier, x.GemLevel))
+                .GroupBy(x => (x.Name,
+                               x.Corrupted,
+                               x.MapTier,
+                               x.GemLevel,
+                               x.Links))
                 .Select(x => x.OrderBy(x => x.Price).First())
                 .ToList();
             return cacheProvider.Set(GetCacheKey(itemType), prices);

--- a/src/Sidekick.Modules.Trade/Components/Prices/PriceNinjaComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Prices/PriceNinjaComponent.razor
@@ -13,6 +13,10 @@ else if (Price != null)
                     <MudText Typo="Typo.caption" Align="Align.Right" Class="d-block">@Resources.LastUpdated : @Price.LastUpdated.ToString("t")</MudText>
                 </MudItem>
                 <MudItem xs="6" Class="d-flex flex-row">
+                    @if (Price.Links >= 5)
+                    {
+                        <MudText Typo="Typo.caption" Color="Color.Tertiary" Class="d-flex mr-4 align-self-center">@Price.Links @Resources.Links</MudText>
+                    }
                     <PriceDisplay Value="Price.Price" Class="justify-start mr-4" />
                     @if (Series != null)
                     {

--- a/src/Sidekick.Modules.Trade/Localization/PoeNinjaResources.cs
+++ b/src/Sidekick.Modules.Trade/Localization/PoeNinjaResources.cs
@@ -14,5 +14,6 @@ namespace Sidekick.Modules.Trade.Localization
         public string PoeNinja => localizer["PoeNinja"];
         public string LastUpdated => localizer["LastUpdated"];
         public string OpenInWebsite => localizer["OpenInWebsite"];
+        public string Links => localizer["Links"];
     }
 }

--- a/src/Sidekick.Modules.Trade/Localization/PoeNinjaResources.resx
+++ b/src/Sidekick.Modules.Trade/Localization/PoeNinjaResources.resx
@@ -120,6 +120,9 @@
   <data name="LastUpdated" xml:space="preserve">
     <value>Last updated</value>
   </data>
+  <data name="Links" xml:space="preserve">
+    <value>Links</value>
+  </data>
   <data name="OpenInWebsite" xml:space="preserve">
     <value>Open in poe.ninja website</value>
   </data>


### PR DESCRIPTION
Also show the number of links in the poe.ninja price view:
![image](https://user-images.githubusercontent.com/4694217/169636975-3c251b79-e0e7-4414-89df-d1e267e4810c.png)
