### PR TITLE
Add support for more poe.ninja items

### DIFF
--- a/src/Sidekick.Apis.PoeNinja/Api/Models/ItemType.cs
+++ b/src/Sidekick.Apis.PoeNinja/Api/Models/ItemType.cs
@@ -22,5 +22,8 @@ namespace Sidekick.Apis.PoeNinja.Api.Models
         Beast,
         Currency,
         Fragment,
+        Invitation,
+        DeliriumOrb,
+        BlightedMap,
     }
 }

--- a/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
@@ -46,6 +46,9 @@ namespace Sidekick.Apis.PoeNinja
             { ItemType.Beast, "beasts" },
             { ItemType.Currency, "currency" },
             { ItemType.Fragment, "fragments" },
+            { ItemType.Invitation, "invitations" },
+            { ItemType.DeliriumOrb, "delirium-orbs" },
+            { ItemType.BlightedMap, "blighted-maps" },
         };
 
         public PoeNinjaClient(
@@ -111,9 +114,15 @@ namespace Sidekick.Apis.PoeNinja
                 if (item.Properties != null)
                 {
                     query = query.Where(x => x.Corrupted == item.Properties.Corrupted
-                                          && x.MapTier == item.Properties.MapTier
                                           && x.GemLevel == item.Properties.GemLevel
                                           && x.IsRelic == item.Properties.IsRelic);
+
+                    if (itemType == ItemType.Map
+                     || itemType == ItemType.UniqueMap
+                     || itemType == ItemType.BlightedMap)
+                    {
+                        query = query.Where(x => x.MapTier == item.Properties.MapTier);
+                    }
 
                     // Poe.ninja has pricings for <5, 5 and 6 links.
                     // <5 being 0 links in their API.
@@ -125,7 +134,10 @@ namespace Sidekick.Apis.PoeNinja
                     query = query.Where(x => x.Links == (highestSocketLinks >= 5 ? highestSocketLinks : 0));
                 }
 
-                return query.FirstOrDefault();
+                if (query.Any())
+                {
+                    return query.FirstOrDefault();
+                }
             }
 
             return null;
@@ -149,7 +161,7 @@ namespace Sidekick.Apis.PoeNinja
             {
                 result.Add(ItemType.Currency);
                 result.Add(ItemType.Fragment);
-
+                result.Add(ItemType.DeliriumOrb);
                 result.Add(ItemType.Incubator);
                 result.Add(ItemType.Oil);
                 result.Add(ItemType.Incubator);
@@ -177,7 +189,13 @@ namespace Sidekick.Apis.PoeNinja
                 switch (item.Metadata.Category)
                 {
                     case Category.DivinationCard: result.Add(ItemType.DivinationCard); break;
-                    case Category.Map: result.Add(ItemType.Map); break;
+                    case Category.Map:
+                        result.Add(ItemType.Map);
+                        result.Add(ItemType.Fragment);
+                        result.Add(ItemType.Scarab);
+                        result.Add(ItemType.Invitation);
+                        result.Add(ItemType.BlightedMap);
+                        break;
                     case Category.Gem: result.Add(ItemType.SkillGem); break;
                     case Category.ItemisedMonster: result.Add(ItemType.Beast); break;
                 }

--- a/src/Sidekick.Modules.Trade/Components/Prices/PriceNinjaComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Prices/PriceNinjaComponent.razor
@@ -10,7 +10,7 @@ else if (Price != null)
             <MudGrid Spacing="4" Justify="Justify.Center" Class="align-center">
                 <MudItem xs="6">
                     <MudText Typo="Typo.subtitle1" Align="Align.Right">@Resources.PoeNinja</MudText>
-                    <MudText Typo="Typo.caption" Align="Align.Right" Class="d-block">@Resources.LastUpdated : @Price.LastUpdated.ToString("t")</MudText>
+                    <MudText Typo="Typo.caption" Align="Align.Right" Class="d-block">@Resources.LastUpdated : @Price.LastUpdated.ToString("g")</MudText>
                 </MudItem>
                 <MudItem xs="6" Class="d-flex flex-row">
                     @if (Price.Links >= 5)


### PR DESCRIPTION
- Blighted maps
- Delirium orbs
- Most fragments should be supported now
- Fix Essences not being found, this is due to MapTier being used as the tier of the essence.