### PR TITLE
Update trade view and add some quality of life features

### DIFF
--- a/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
@@ -28,17 +28,17 @@
                 </div>
 
                 <MudGrid Spacing="2">
-                    <MudItem xs="12" sm="6">
+                    <MudItem xs="12" sm="4">
                         <ClassFilter @bind-Value="PropertyFilters.Class" Item="Item" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Armour" Title="@Resources.Filters_Armour" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Weapon" Title="@Resources.Filters_Weapon" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Map" Title="@Resources.Filters_Map" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Misc" Title="@Resources.Filters_Misc" />
                     </MudItem>
-                    <MudItem xs="12" sm="6">
+                    <MudItem xs="12" sm="8">
                         @if (ModifierVisible)
                         {
-                            <div class="mb-2">
+                            <div class="mb-2 alternate-background">
                                 <MudText Typo="Typo.h5" Class="px-2">@Resources.Filters_Modifiers</MudText>
                                 <ModifierFiltersComponent Filters="ModifierFilters.Enchant" />
                                 <ModifierFiltersComponent Filters="ModifierFilters.Scourge" AdditionalClassNames="orange-text" />
@@ -51,7 +51,7 @@
 
                         @if (PseudoVisible)
                         {
-                            <div class="mb-2">
+                            <div class="mb-2 alternate-background">
                                 <MudText Typo="Typo.h5" Class="px-2">@Resources.Filters_Pseudo</MudText>
                                 <ModifierFiltersComponent Filters="ModifierFilters.Pseudo" />
                             </div>

--- a/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
@@ -40,12 +40,12 @@
                         {
                             <div class="mb-2 alternate-background">
                                 <MudText Typo="Typo.h5" Class="px-2">@Resources.Filters_Modifiers</MudText>
-                                <ModifierFiltersComponent Filters="ModifierFilters.Enchant" />
-                                <ModifierFiltersComponent Filters="ModifierFilters.Scourge" AdditionalClassNames="orange-text" />
+                                <ModifierFiltersComponent Filters="ModifierFilters.Enchant" AdditionalClassNames="enchant-text" />
+                                <ModifierFiltersComponent Filters="ModifierFilters.Scourge" AdditionalClassNames="scourge-text" />
                                 <ModifierFiltersComponent Filters="ModifierFilters.Implicit" />
                                 <ModifierFiltersComponent Filters="ModifierFilters.Explicit" />
-                                <ModifierFiltersComponent Filters="ModifierFilters.Crafted" />
-                                <ModifierFiltersComponent Filters="ModifierFilters.Fractured" AdditionalClassNames="brown-text" />
+                                <ModifierFiltersComponent Filters="ModifierFilters.Crafted" AdditionalClassNames="crafted-text" />
+                                <ModifierFiltersComponent Filters="ModifierFilters.Fractured" AdditionalClassNames="fractured-text" />
                             </div>
                         }
 

--- a/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor
@@ -28,14 +28,14 @@
                 </div>
 
                 <MudGrid Spacing="2">
-                    <MudItem xs="12" sm="4">
+                    <MudItem xs="12" sm="6">
                         <ClassFilter @bind-Value="PropertyFilters.Class" Item="Item" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Armour" Title="@Resources.Filters_Armour" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Weapon" Title="@Resources.Filters_Weapon" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Map" Title="@Resources.Filters_Map" />
                         <PropertyFiltersComponent Filters="PropertyFilters.Misc" Title="@Resources.Filters_Misc" />
                     </MudItem>
-                    <MudItem xs="12" sm="8">
+                    <MudItem xs="12" sm="6">
                         @if (ModifierVisible)
                         {
                             <div class="mb-2 alternate-background">

--- a/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Filters/FiltersComponent.razor.css
@@ -1,2 +1,7 @@
 ::deep .mud-checkbox .mud-button-root {
-  padding: 4px 8px; }
+    padding: 4px 8px;
+}
+
+::deep .alternate-background > div:nth-child(odd) {
+    background-color: var(--mud-palette-background)
+}

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
@@ -2,7 +2,7 @@
 <div>
     <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="@("font-smallcaps mb-1 d-flex " + AdditionalClassNames)">
         <div class="d-flex flex-row justify-start align-center">
-            <MudText Class="flex-grow-1 mr-2">@Filter.Modifier.Text</MudText>
+            <MudText Class="flex-grow-1 my-1 mr-2">@Filter.Modifier.Text</MudText>
             @if (Filter.Modifier.OptionValue == null && Filter.Modifier.Values.Count > 0)
             {
                 <div class="filter-min"

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
@@ -1,17 +1,24 @@
 
 <div>
-    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Label="@Filter.Modifier.Text" Class="@("font-smallcaps " + AdditionalClassNames)" />
-    @if (Expanded)
-    {
-        <div class="pl-12 d-flex flex-row justify-start align-center">
-            <div style="max-width: 100px;">
-                <MudTextField @bind-Value="Filter.Min" Label="@Resources.Filters_Min" Variant="Variant.Filled" Margin="Margin.Dense" />
+    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="@("font-smallcaps mb-1 d-flex" + AdditionalClassNames)">
+        <div class="d-flex flex-row justify-start align-center">
+            <MudText Class="flex-grow-1 mr-4">@Filter.Modifier.Text</MudText>
+            <div class="filter-min"
+                 @onwheel="OnWheelMin"
+                 @oncontextmenu="ClearMin"
+                 @oncontextmenu:preventDefault
+                 style="max-width: 67px;">
+                <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
             </div>
-            <div class="ml-2" style="max-width: 100px;">
-                <MudTextField @bind-Value="Filter.Max" Label="@Resources.Filters_Max" Variant="Variant.Filled" Margin="Margin.Dense" />
+            <div class="filter-max mr-4"
+                 @onwheel="OnWheelMax"
+                 @oncontextmenu="ClearMax"
+                 @oncontextmenu:preventDefault
+                 style="max-width: 67px;">
+                <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
             </div>
         </div>
-    }
+    </MudCheckBox>
 </div>
 
 @code {
@@ -21,5 +28,27 @@
 
     [Parameter] public string AdditionalClassNames { get; set; }
 
-    private bool Expanded => Filter.Enabled && Filter.Modifier.OptionValue == null && Filter.Modifier.Values.Count > 0;
+    private void ClearMin()
+    {
+        Filter.Min = null;
+    }
+
+    private void OnWheelMin(WheelEventArgs args)
+    {
+        if (!Filter.Min.HasValue) Filter.Min = 0;
+        if (args.DeltaY < 0) Filter.Min += 1;
+        else Filter.Min -= 1;
+    }
+
+    private void OnWheelMax(WheelEventArgs args)
+    {
+        if (!Filter.Max.HasValue) Filter.Max = 0;
+        if (args.DeltaY < 0) Filter.Max += 1;
+        else Filter.Max -= 1;
+    }
+
+    private void ClearMax()
+    {
+        Filter.Max = null;
+    }
 }

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
@@ -2,21 +2,24 @@
 <div>
     <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="@("font-smallcaps mb-1 d-flex " + AdditionalClassNames)">
         <div class="d-flex flex-row justify-start align-center">
-            <MudText Class="flex-grow-1 mr-4">@Filter.Modifier.Text</MudText>
-            <div class="filter-min"
-                 @onwheel="OnWheelMin"
-                 @onwheel:preventDefault
-                 @oncontextmenu="ClearMin"
-                 @oncontextmenu:preventDefault>
-                <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
-            </div>
-            <div class="filter-max my-1 mr-4"
-                 @onwheel="OnWheelMax"
-                 @onwheel:preventDefault
-                 @oncontextmenu="ClearMax"
-                 @oncontextmenu:preventDefault>
-                <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
-            </div>
+            <MudText Class="flex-grow-1 mr-2">@Filter.Modifier.Text</MudText>
+            @if (Filter.Modifier.OptionValue == null && Filter.Modifier.Values.Count > 0)
+            {
+                <div class="filter-min"
+                     @onwheel="OnWheelMin"
+                     @onwheel:preventDefault
+                     @oncontextmenu="ClearMin"
+                     @oncontextmenu:preventDefault>
+                    <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
+                </div>
+                <div class="filter-max my-1 mr-2"
+                     @onwheel="OnWheelMax"
+                     @onwheel:preventDefault
+                     @oncontextmenu="ClearMax"
+                     @oncontextmenu:preventDefault>
+                    <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
+                </div>
+            }
         </div>
     </MudCheckBox>
 </div>

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
@@ -1,20 +1,20 @@
 
 <div>
-    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="@("font-smallcaps mb-1 d-flex" + AdditionalClassNames)">
+    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="@("font-smallcaps mb-1 d-flex " + AdditionalClassNames)">
         <div class="d-flex flex-row justify-start align-center">
             <MudText Class="flex-grow-1 mr-4">@Filter.Modifier.Text</MudText>
             <div class="filter-min"
                  @onwheel="OnWheelMin"
+                 @onwheel:preventDefault
                  @oncontextmenu="ClearMin"
-                 @oncontextmenu:preventDefault
-                 style="max-width: 67px;">
+                 @oncontextmenu:preventDefault>
                 <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
             </div>
-            <div class="filter-max mr-4"
+            <div class="filter-max my-1 mr-4"
                  @onwheel="OnWheelMax"
+                 @onwheel:preventDefault
                  @oncontextmenu="ClearMax"
-                 @oncontextmenu:preventDefault
-                 style="max-width: 67px;">
+                 @oncontextmenu:preventDefault>
                 <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
             </div>
         </div>
@@ -28,16 +28,16 @@
 
     [Parameter] public string AdditionalClassNames { get; set; }
 
-    private void ClearMin()
-    {
-        Filter.Min = null;
-    }
-
     private void OnWheelMin(WheelEventArgs args)
     {
         if (!Filter.Min.HasValue) Filter.Min = 0;
         if (args.DeltaY < 0) Filter.Min += 1;
         else Filter.Min -= 1;
+    }
+
+    private void ClearMin()
+    {
+        Filter.Min = null;
     }
 
     private void OnWheelMax(WheelEventArgs args)

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor.css
@@ -5,6 +5,7 @@
 ::deep .filter-min,
 ::deep .filter-max {
     max-width: 50px;
+    min-width: 50px;
     border: 1px solid var(--mud-palette-lines-inputs);
     border-radius: var(--mud-default-borderradius);
 }

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor.css
@@ -1,0 +1,26 @@
+::deep label > p {
+    flex-grow: 1;
+}
+
+::deep .filter-min,
+::deep .filter-max {
+    max-width: 50px;
+    border: 1px solid var(--mud-palette-lines-inputs);
+    border-radius: var(--mud-default-borderradius);
+}
+
+::deep .filter-min {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+::deep .filter-max {
+    border-left: 0;
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+}
+
+    ::deep .filter-min input,
+    ::deep .filter-max input {
+        text-align: center;
+    }

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
@@ -2,21 +2,24 @@
 <div>
     <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="font-smallcaps mb-1 d-flex">
         <div class="d-flex flex-row justify-start align-center">
-            <MudText Class="@($"flex-grow-1 mr-4 {GetFilterTextClass()}")">@Filter.Text</MudText>
-            <div class="filter-min"
-                 @onwheel="OnWheelMin"
-                 @onwheel:preventDefault
-                 @oncontextmenu="ClearMin"
-                 @oncontextmenu:preventDefault>
-                <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
-            </div>
-            <div class="filter-max my-1 mr-4"
-                 @onwheel="OnWheelMax"
-                 @onwheel:preventDefault
-                 @oncontextmenu="ClearMax"
-                 @oncontextmenu:preventDefault>
-                <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
-            </div>
+            <MudText Class="@($"flex-grow-1 mr-2 {GetFilterTextClass()}")">@Filter.Text</MudText>
+            @if (Filter.ValueType == FilterValueType.Double || Filter.ValueType == FilterValueType.Int)
+            {
+                <div class="filter-min"
+                     @onwheel="OnWheelMin"
+                     @onwheel:preventDefault
+                     @oncontextmenu="ClearMin"
+                     @oncontextmenu:preventDefault>
+                    <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
+                </div>
+                <div class="filter-max my-1 mr-2"
+                     @onwheel="OnWheelMax"
+                     @onwheel:preventDefault
+                     @oncontextmenu="ClearMax"
+                     @oncontextmenu:preventDefault>
+                    <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
+                </div>
+            }
         </div>
     </MudCheckBox>
 </div>

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
@@ -1,17 +1,24 @@
 
 <div>
-    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Label="@Filter.Text" Class="font-smallcaps" />
-    @if (Expanded)
-    {
-        <div class="pl-12 d-flex flex-row justify-start align-center">
-            <div style="max-width: 100px;">
-                <MudTextField @bind-Value="Filter.Min" Label="@Resources.Filters_Min" Variant="Variant.Filled" Margin="Margin.Dense" />
+    <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="font-smallcaps mb-1 d-flex">
+        <div class="d-flex flex-row justify-start align-center">
+            <MudText Class="@($"flex-grow-1 mr-4 {GetFilterTextClass()}")">@Filter.Text</MudText>
+            <div class="filter-min"
+                 @onwheel="OnWheelMin"
+                 @onwheel:preventDefault
+                 @oncontextmenu="ClearMin"
+                 @oncontextmenu:preventDefault>
+                <MudInput @bind-Value="Filter.Min" Placeholder="@Resources.Filters_Min" DisableUnderLine />
             </div>
-            <div class="ml-2" style="max-width: 100px;">
-                <MudTextField @bind-Value="Filter.Max" Label="@Resources.Filters_Max" Variant="Variant.Filled" Margin="Margin.Dense" />
+            <div class="filter-max my-1 mr-4"
+                 @onwheel="OnWheelMax"
+                 @onwheel:preventDefault
+                 @oncontextmenu="ClearMax"
+                 @oncontextmenu:preventDefault>
+                <MudInput @bind-Value="Filter.Max" Placeholder="@Resources.Filters_Max" DisableUnderLine />
             </div>
         </div>
-    }
+    </MudCheckBox>
 </div>
 
 @code {
@@ -19,5 +26,36 @@
 
     [Parameter] public PropertyFilter Filter { get; set; }
 
-    private bool Expanded => Filter.Enabled && (Filter.ValueType == FilterValueType.Double || Filter.ValueType == FilterValueType.Int);
+    private string GetFilterTextClass()
+    {
+        return Filter.Type switch
+        {
+            PropertyFilterType.Misc_Corrupted => "corrupted-text",
+            _ => string.Empty
+        };
+    }
+
+    private void OnWheelMin(WheelEventArgs args)
+    {
+        if (!Filter.Min.HasValue) Filter.Min = 0;
+        if (args.DeltaY < 0) Filter.Min += 1;
+        else Filter.Min -= 1;
+    }
+
+    private void ClearMin()
+    {
+        Filter.Min = null;
+    }
+
+    private void OnWheelMax(WheelEventArgs args)
+    {
+        if (!Filter.Max.HasValue) Filter.Max = 0;
+        if (args.DeltaY < 0) Filter.Max += 1;
+        else Filter.Max -= 1;
+    }
+
+    private void ClearMax()
+    {
+        Filter.Max = null;
+    }
 }

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor
@@ -2,7 +2,7 @@
 <div>
     <MudCheckBox @bind-Checked="Filter.Enabled" Color="Color.Primary" Class="font-smallcaps mb-1 d-flex">
         <div class="d-flex flex-row justify-start align-center">
-            <MudText Class="@($"flex-grow-1 mr-2 {GetFilterTextClass()}")">@Filter.Text</MudText>
+            <MudText Class="@($"flex-grow-1 my-1 mr-2 {GetFilterTextClass()}")">@Filter.Text</MudText>
             @if (Filter.ValueType == FilterValueType.Double || Filter.ValueType == FilterValueType.Int)
             {
                 <div class="filter-min"

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor.css
@@ -5,6 +5,7 @@
 ::deep .filter-min,
 ::deep .filter-max {
     max-width: 50px;
+    min-width: 50px;
     border: 1px solid var(--mud-palette-lines-inputs);
     border-radius: var(--mud-default-borderradius);
 }

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFilterComponent.razor.css
@@ -25,15 +25,6 @@
         text-align: center;
     }
 
-::deep .scourge-text {
-    color: #FF6E25;
-}
-
-::deep .fractured-text {
-    color: #A29162;
-}
-
-::deep .enchant-text,
-::deep .crafted-text {
-    color: #B4B4FF;
+::deep .corrupted-text {
+    color: #d20000;
 }

--- a/src/Sidekick.Modules.Trade/Components/Filters/PropertyFiltersComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/PropertyFiltersComponent.razor
@@ -1,7 +1,7 @@
 
 @if (Filters != null && Filters.Count > 0)
 {
-    <div class="mb-2">
+    <div class="mb-2 alternate-background">
         <MudText Typo="Typo.h5" Class="px-2">@Title</MudText>
         @foreach (var filter in Filters)
         {

--- a/src/Sidekick.Modules.Trade/Components/Items/ItemComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Items/ItemComponent.razor
@@ -31,19 +31,19 @@
             <ItemModifiersComponent Item="Item" Modifiers="Item.Modifiers.Fractured" />
             @if (!Item.Properties.Identified)
             {
-                <div class="red-text">
+                <div class="unidentified-text">
                     <MudText Typo="Typo.body1" Align="Align.Center" Class="font-smallcaps">@Resources.Unidentified</MudText>
                 </div>
             }
             @if (Item.Properties.Corrupted)
             {
-                <div class="red-text">
+                <div class="corrupted-text">
                     <MudText Typo="Typo.body1" Align="Align.Center" Class="font-smallcaps">@Resources.Corrupted</MudText>
                 </div>
             }
             @if (Item.Properties.Scourged)
             {
-                <div class="orange-text">
+                <div class="scourge-text">
                     <MudText Typo="Typo.body1" Align="Align.Center" Class="font-smallcaps">@Resources.Scourged</MudText>
                 </div>
             }

--- a/src/Sidekick.Modules.Trade/Components/Items/ItemComponent.razor.css
+++ b/src/Sidekick.Modules.Trade/Components/Items/ItemComponent.razor.css
@@ -30,15 +30,18 @@ img {
     color: rgba(255,255,255, 0.7);
 }
 
-.red-text {
+.unidentified-text,
+.corrupted-text {
     color: #d20000;
 }
 
-.orange-text {
-    color: #FF6E25; }
+.scourge-text {
+    color: #FF6E25;
+}
 
-.brown-text {
-    color: #A29162; }
+.fractured-text {
+    color: #A29162;
+}
 
 .note-text {
     color: #AA9E82;

--- a/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
+++ b/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
@@ -5,6 +5,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="Components\Filters\ModifierFilterComponent.razor.css" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Components\Filters\ModifierFilterComponent.razor.css" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Sidekick.Apis.PoeNinja\Sidekick.Apis.PoeNinja.csproj" />
     <ProjectReference Include="..\Sidekick.Apis.PoePriceInfo\Sidekick.Apis.PoePriceInfo.csproj" />
     <ProjectReference Include="..\Sidekick.Apis.Poe\Sidekick.Apis.Poe.csproj" />

--- a/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
+++ b/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
@@ -5,16 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Components\Filters\ModifierFilterComponent.razor.css" />
-    <None Remove="Components\Filters\PropertyFilterComponent.razor.css" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Content Include="Components\Filters\ModifierFilterComponent.razor.css" />
-    <Content Include="Components\Filters\PropertyFilterComponent.razor.css" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\Sidekick.Apis.PoeNinja\Sidekick.Apis.PoeNinja.csproj" />
     <ProjectReference Include="..\Sidekick.Apis.PoePriceInfo\Sidekick.Apis.PoePriceInfo.csproj" />
     <ProjectReference Include="..\Sidekick.Apis.Poe\Sidekick.Apis.Poe.csproj" />

--- a/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
+++ b/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
@@ -6,10 +6,12 @@
 
   <ItemGroup>
     <None Remove="Components\Filters\ModifierFilterComponent.razor.css" />
+    <None Remove="Components\Filters\PropertyFilterComponent.razor.css" />
   </ItemGroup>
 
   <ItemGroup>
     <Content Include="Components\Filters\ModifierFilterComponent.razor.css" />
+    <Content Include="Components\Filters\PropertyFilterComponent.razor.css" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Added more colors to the mods to match the colors in-game
- Fixed existing mod colors. Colors from MudBlazor were being used instead.
- Updated the trade filters UI to be more convienent
- Shift+Wheel or Ctrl+Wheel over the minimum and maximum fields will increase and decrease their values
- Right-clicking a minimum or maximum field will clear its value

![image](https://user-images.githubusercontent.com/4694217/169676516-f480af7a-5012-480b-8c5d-57dfd2e196de.png)
