### PR TITLE
fix: chat links not showing attributes in pop-up

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/ParsingItem.cs
+++ b/src/Sidekick.Apis.Poe/Parser/ParsingItem.cs
@@ -1,6 +1,7 @@
 using System.Text.RegularExpressions;
 using Sidekick.Apis.Poe.Parser.Tokenizers;
 using Sidekick.Common.Game.Items;
+using Sidekick.Apis.Poe.Modifiers;
 
 namespace Sidekick.Apis.Poe.Parser
 {
@@ -18,8 +19,8 @@ namespace Sidekick.Apis.Poe.Parser
         public ParsingItem(string text)
         {
             Text = new ItemNameTokenizer().CleanString(text);
-
-            Blocks = text
+            Text = ModifierProvider.RemoveSquareBrackets(Text);
+            Blocks = Text
                 .Split(SeparatorPattern, StringSplitOptions.RemoveEmptyEntries)
                 .Select(x => new ParsingBlock(x.Trim('\r', '\n')))
                 .ToList();


### PR DESCRIPTION
The parsing for item descriptions from chat were not being read correctly and missing stats. This will parse the output of a copy paste from chat 

`Item Class: Body Armours
Rarity: Rare
Glyph Shell
Expert Hexer's Robe
--------
[EnergyShield|Energy Shield]: 434 (augmented)
--------
Requirements:
Level: 65
[Intelligence|Int]: 157
--------
Item Level: 79
--------
136% increased [EnergyShield|Energy Shield]
+35 to maximum Life
+53 to [Spirit|Spirit]
+23 to [Intelligence|Intelligence]
+141 to [StunThreshold|Stun Threshold]
48% reduced [Poison|Poison] Duration on you
`

in the same manor one from your inventory does:

`Item Class: Body Armours
Rarity: Rare
Spirit Suit
Advanced Feathered Robe
--------
Quality: +6% (augmented)
Energy Shield: 122 (augmented)
--------
Requirements:
Level: 45
Int: 65 (augmented)
--------
Sockets: S S S 
--------
Item Level: 52
--------
+24% to Fire Resistance (rune)
+12% to Cold Resistance (rune)
--------
19% increased Energy Shield
+64 to maximum Life
+42 to Spirit
30% reduced Attribute Requirements
+13% to Fire Resistance
+27% to Lightning Resistance
--------
Corrupted
`