### PR TITLE
fix: corrected paramater parsing for trade searches

### DIFF
--- a/src/Sidekick.Apis.Poe/Trade/Requests/Filters/StatType.cs
+++ b/src/Sidekick.Apis.Poe/Trade/Requests/Filters/StatType.cs
@@ -8,6 +8,12 @@ namespace Sidekick.Apis.Poe.Trade.Requests.Filters
         And,
 
         [EnumValue("count")]
-        Count
+        Count,
+
+        [EnumValue("not")]
+        Not,
+
+        [EnumValue("if")]
+        If
     }
 }


### PR DESCRIPTION
Issue:

When you search an item and set min/max values, they do not send the proper syntax for the trade api.

Fixed the structuring and stat filtering