### PR TITLE
Handle HTTP redirects in PoeTradeHandler

### DIFF
--- a/src/Sidekick.Apis.Poe/Bulk/BulkTradeService.cs
+++ b/src/Sidekick.Apis.Poe/Bulk/BulkTradeService.cs
@@ -82,6 +82,10 @@ namespace Sidekick.Apis.Poe.Bulk
 
                 return new BulkResponseModel(result);
             }
+            catch (SidekickException)
+            {
+                throw;
+            }
             catch (Exception e)
             {
                 logger.LogError(e, "An exception occured while parsing the API response. {data}", content);

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
@@ -101,7 +101,20 @@ public class PoeTradeHandler
 
         logger.LogInformation("[PoeTradeHandler] Redirecting to {redirectUri}.", redirectUri);
 
-        request.RequestUri = redirectUri;
-        return await base.SendAsync(request, cancellationToken);
+        var redirectRequest = new HttpRequestMessage(request.Method, redirectUri);
+
+        // Copy headers from the original request
+        foreach (var header in request.Headers)
+        {
+            redirectRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+        }
+
+        if (request.Content != null)
+        {
+            redirectRequest.Content = request.Content;
+        }
+
+        // Retry the request with the new URI
+        return await base.SendAsync(redirectRequest, cancellationToken);
     }
 }

--- a/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
@@ -137,6 +137,10 @@ public class TradeSearchService
                 return result;
             }
         }
+        catch (SidekickException)
+        {
+            throw;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "[Trade API] Exception thrown while querying trade api.");

--- a/src/Sidekick.Common/Game/Languages/GameLanguageProvider.cs
+++ b/src/Sidekick.Common/Game/Languages/GameLanguageProvider.cs
@@ -67,4 +67,11 @@ public class GameLanguageProvider(ISettingsService settingsService) : IGameLangu
     {
         return Language.GetType() == InvariantLanguage.GetType();
     }
+
+    public bool IsChinese()
+    {
+        var languages = GetList();
+        var chineseLanguage = languages.FirstOrDefault(x=>x.LanguageCode == "zh");
+        return chineseLanguage?.ImplementationType == Language.GetType();
+    }
 }

--- a/src/Sidekick.Common/Game/Languages/IGameLanguageProvider.cs
+++ b/src/Sidekick.Common/Game/Languages/IGameLanguageProvider.cs
@@ -11,4 +11,6 @@ public interface IGameLanguageProvider : IInitializableService
     List<GameLanguageAttribute> GetList();
 
     bool IsEnglish();
+
+    bool IsChinese();
 }

--- a/src/Sidekick.Common/Game/Languages/Implementations/GameLanguageZhTw.cs
+++ b/src/Sidekick.Common/Game/Languages/Implementations/GameLanguageZhTw.cs
@@ -1,6 +1,6 @@
 namespace Sidekick.Common.Game.Languages.Implementations;
 
-[GameLanguage("Traditional Chinese", "zh")]
+// [GameLanguage("Traditional Chinese", "zh")]
 public class GameLanguageZhTw : IGameLanguage
 {
     public string PoeTradeBaseUrl => new("http://www.pathofexile.tw/trade/");

--- a/src/Sidekick.Common/ServiceCollectionExtensions.cs
+++ b/src/Sidekick.Common/ServiceCollectionExtensions.cs
@@ -31,8 +31,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBrowserProvider, BrowserProvider>();
         services.AddSingleton<ICacheProvider, CacheProvider>();
         services.AddSingleton<IGameLogProvider, GameLogProvider>();
-        services.AddSingleton<ISettingsService, SettingsService>();
 
+        services.AddSidekickInitializableService<ISettingsService, SettingsService>();
         services.AddSidekickInitializableService<IGameLanguageProvider, GameLanguageProvider>();
         services.AddSidekickInitializableService<IUiLanguageProvider, UiLanguageProvider>();
 

--- a/src/Sidekick.Common/Settings/ISettingsService.cs
+++ b/src/Sidekick.Common/Settings/ISettingsService.cs
@@ -1,6 +1,8 @@
+using Sidekick.Common.Initialization;
+
 namespace Sidekick.Common.Settings;
 
-public interface ISettingsService
+public interface ISettingsService : IInitializableService
 {
     /// <summary>
     /// Event when any setting is changed.

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -14,6 +14,19 @@ namespace Sidekick.Common.Settings
     {
         public event Action? OnSettingsChanged;
 
+        public int Priority { get; set; } = int.MinValue;
+
+        public async Task Initialize()
+        {
+            // If the language is Chinese, we are forcing the use invariant trade results flag.
+            var useInvariantTradeResults = await GetBool(SettingKeys.UseInvariantTradeResults);
+            var languageParser = await GetString(SettingKeys.LanguageParser);
+            if (languageParser == "zh" && !useInvariantTradeResults)
+            {
+                await Set(SettingKeys.UseInvariantTradeResults, true);
+            }
+        }
+
         public async Task<bool> GetBool(string key)
         {
             await using var dbContext = new SidekickDbContext(dbContextOptions);


### PR DESCRIPTION
Added logic to handle HTTP redirect status codes (301, 302, and 307) within PoeTradeHandler. This includes extracting the "Location" header and resending the request to the redirected URL. This ensures proper handling of redirects during API interactions.