### PR TITLE
Fix exception when price checking corrupted gems

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
@@ -51,6 +51,16 @@ namespace Sidekick.Apis.Poe.Parser.Metadata
             parsingBlock.Parsed = true;
 
             var itemRarity = headerParser.ParseRarity(parsingItem);
+            
+            var canBeVaalGem = itemRarity == Rarity.Gem && parsingItem.Blocks.Count > 7;
+            if (parsingItem.Blocks[5].Lines.Count > 0 && canBeVaalGem)
+            {
+                data.NameAndTypeDictionary.TryGetValue(parsingItem.Blocks[5].Lines[0].Text, value: out var vaalGem);
+                if (vaalGem != null)
+                {
+                    return vaalGem.First();
+                }
+            }
 
             // Get name and type text
             string? name = null;

--- a/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
@@ -53,9 +53,9 @@ namespace Sidekick.Apis.Poe.Parser.Metadata
             var itemRarity = headerParser.ParseRarity(parsingItem);
             
             var canBeVaalGem = itemRarity == Rarity.Gem && parsingItem.Blocks.Count > 7;
-            if (parsingItem.Blocks[5].Lines.Count > 0 && canBeVaalGem)
+            if (canBeVaalGem && parsingItem.Blocks[5].Lines.Count > 0)
             {
-                data.NameAndTypeDictionary.TryGetValue(parsingItem.Blocks[5].Lines[0].Text, value: out var vaalGem);
+                data.NameAndTypeDictionary.TryGetValue(parsingItem.Blocks[5].Lines[0].Text, out var vaalGem);
                 if (vaalGem != null)
                 {
                     return vaalGem.First();

--- a/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs
@@ -52,12 +52,6 @@ namespace Sidekick.Apis.Poe.Parser.Metadata
 
             var itemRarity = headerParser.ParseRarity(parsingItem);
 
-            var canBeVaalGem = itemRarity == Rarity.Gem && parsingItem.Blocks.Count > 7;
-            if (canBeVaalGem && data.NameAndTypeDictionary.TryGetValue(parsingItem.Blocks[5].Lines[0].Text, out var vaalGem))
-            {
-                return vaalGem.First();
-            }
-
             // Get name and type text
             string? name = null;
             string? type = null;


### PR DESCRIPTION
This part of the parser does not work or I don't seem to grasp the functionality of this.
https://github.com/Sidekick-Poe/Sidekick/blob/9c4be790e0e1db53d6f5e3b374c416c45a50d46b/src/Sidekick.Apis.Poe/Parser/Metadata/MetadataParser.cs#L55-L59

It tries to parse an empty line which creates the error since there is no text.

The parser already gets the corrupted state from the property parse I didnt go through the code but I assume that property is used to set the variable for the price check page as well.

`data.NameAndTypeDictionary.TryGetValue(parsingItem.Blocks[5].Lines[0].Text`
Even if that empty block would not be there it would still parse the wrong text.
Thats why I removed the vaal gem part from the code.

These are the blocks from zero to last element as you can see `[]` would be the sixth element even if that element would not be there it would parse `Skills can be managed in the Skills Panel.`

The gem text was taken from the mentioned issue:

```
[Item Class: Skill Gems, Rarity: Gem, Explosive Shot]
[Attack, AoE, Ammunition, Projectile, Fire, Detonator, Level: 16 (augmented), 15 Levels from Gem...]
[Requirements:, Level: 64, Crossbow, Str: 80, Dex: 80]
[Sockets: G G G ]
[...]
[]
[Skills can be managed in the Skills Panel.]
[Corrupted]
```
Closes #384