### PR TITLE
modify @last with no @ combine after replaced for eg. /invite @last

### DIFF
--- a/src/Sidekick.Modules.Chat/Keybinds/ChatKeybindHandler.cs
+++ b/src/Sidekick.Modules.Chat/Keybinds/ChatKeybindHandler.cs
@@ -58,7 +58,7 @@ namespace Sidekick.Modules.Chat.Keybinds
                     return;
                 }
 
-                command = command.Replace(TokenLast, command.StartsWith("@") ? "@" + characterName : characterName);
+                command = command.Replace(TokenLast, command.StartsWith("@") ? characterName : characterName);
             }
 
             await clipboard.SetText(command);


### PR DESCRIPTION
I encountered an issue when trying to set up a chat command to invite a friend to a party using the command /invite @last. It turns out the program adds '@' in front of the name, causing it to fail as it cannot find the player's name. I made adjustments to ensure it handles this case.

The '@last' command, used for whispering, also still works as intended.