### PR TITLE
Improve the initialization by not forcing the window to be on top all the time.

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/Headers/HeaderParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Headers/HeaderParser.cs
@@ -98,7 +98,6 @@ public class HeaderParser
         };
     }
 
-
     public Rarity ParseRarity(ParsingItem parsingItem)
     {
         foreach (var pattern in RarityPatterns)

--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -109,9 +109,9 @@ namespace Sidekick.Common.Blazor.Initialization
                 // If we have a successful initialization, we delay for half a second to show the
                 // "Ready" label on the UI before closing the view
                 Completed = Count;
-                await ReportProgress();
 
                 await StartCountdownToClose();
+                await ReportProgress();
             }
             catch (SidekickException e)
             {

--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -7,7 +7,6 @@ using Microsoft.Extensions.Options;
 using Sidekick.Common.Browser;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Exceptions;
-using Sidekick.Common.Game.Languages;
 using Sidekick.Common.Initialization;
 using Sidekick.Common.Keybinds;
 using Sidekick.Common.Platform;
@@ -58,8 +57,6 @@ namespace Sidekick.Common.Blazor.Initialization
         public Task? InitializationTask { get; set; }
 
         public override SidekickViewType ViewType => SidekickViewType.Modal;
-
-        public override int ViewHeight => 210;
 
         private int TimeLeftToCloseView { get; set; } = 4;
 
@@ -114,15 +111,7 @@ namespace Sidekick.Common.Blazor.Initialization
                 Completed = Count;
                 await ReportProgress();
 
-                if (Debugger.IsAttached)
-                {
-                    await ViewLocator.Open("/development");
-                    await CurrentView.Close();
-                }
-                else
-                {
-                    await StartCountdownToClose();
-                }
+                await StartCountdownToClose();
             }
             catch (SidekickException e)
             {
@@ -140,7 +129,15 @@ namespace Sidekick.Common.Blazor.Initialization
                 await Task.Delay(1000);
                 TimeLeftToCloseView--;
             }
-            await CurrentView.Close();
+
+            if (Debugger.IsAttached)
+            {
+                NavigationManager.NavigateTo("/development");
+            }
+            else
+            {
+                await CurrentView.Close();
+            }
         }
 
         private async Task Run(Action action)

--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -58,7 +58,7 @@ namespace Sidekick.Common.Blazor.Initialization
 
         public override SidekickViewType ViewType => SidekickViewType.Modal;
 
-        private int TimeLeftToCloseView { get; set; } = 4;
+        private int TimeLeftToCloseView { get; set; }
 
         protected override async Task OnInitializedAsync()
         {
@@ -123,6 +123,8 @@ namespace Sidekick.Common.Blazor.Initialization
 
         private async Task StartCountdownToClose()
         {
+            TimeLeftToCloseView = Debugger.IsAttached ? 1 : 4;
+
             while (TimeLeftToCloseView > 0)
             {
                 StateHasChanged();

--- a/src/Sidekick.Common.Blazor/Setup/Setup.razor
+++ b/src/Sidekick.Common.Blazor/Setup/Setup.razor
@@ -140,7 +140,7 @@
         var apiLeaguesHash = JsonSerializer.Serialize(leagues).GetDeterministicHashCode();
         await SettingsService.Set(SettingKeys.LeaguesHash, apiLeaguesHash);
 
-        CurrentView.SetSize(height: 210);
+        CurrentView.SetSize(height: 220);
         NavigationManager.NavigateTo("/initialize");
     }
 

--- a/src/Sidekick.Common.Blazor/Setup/SetupPage.razor
+++ b/src/Sidekick.Common.Blazor/Setup/SetupPage.razor
@@ -7,6 +7,4 @@
 
     public override SidekickViewType ViewType => SidekickViewType.Modal;
 
-    public override int ViewHeight => 210;
-    
 }

--- a/src/Sidekick.Common.Ui/Views/SidekickView.cs
+++ b/src/Sidekick.Common.Ui/Views/SidekickView.cs
@@ -40,7 +40,7 @@ namespace Sidekick.Common.Ui.Views
         /// </summary>
         public virtual int ViewHeight => ViewType switch
         {
-            SidekickViewType.Modal => 260,
+            SidekickViewType.Modal => 220,
             _ => 600,
         };
 

--- a/src/Sidekick.Common.Updater/Components/Update.razor
+++ b/src/Sidekick.Common.Updater/Components/Update.razor
@@ -81,8 +81,6 @@
 
     public override SidekickViewType ViewType => SidekickViewType.Modal;
 
-    public override int ViewHeight => 210;
-
     protected override async Task OnInitializedAsync()
     {
         await base.OnInitializedAsync();

--- a/src/Sidekick.Wpf/MainWindow.xaml.cs
+++ b/src/Sidekick.Wpf/MainWindow.xaml.cs
@@ -38,6 +38,8 @@ public partial class MainWindow
 
     public void Ready()
     {
+        var wasAlreadyVisible = WebView.Visibility == Visibility.Visible;
+
         // This avoids the white flicker which is caused by the page content not being loaded initially. We show the webview control only when the content is ready.
         WebView.Visibility = Visibility.Visible;
 
@@ -45,7 +47,10 @@ public partial class MainWindow
         Background = (Brush?)new BrushConverter().ConvertFrom("#000000");
         Opacity = 0.01;
 
-        Activate();
+        if (!wasAlreadyVisible)
+        {
+            Activate();
+        }
     }
 
     protected override void OnClosing(CancelEventArgs e)

--- a/src/Sidekick.Wpf/Services/WpfViewLocator.cs
+++ b/src/Sidekick.Wpf/Services/WpfViewLocator.cs
@@ -66,7 +66,7 @@ namespace Sidekick.Wpf.Services
                 }
                 else if (view.ViewType == SidekickViewType.Modal)
                 {
-                    window.Topmost = true;
+                    window.Topmost = false;
                     window.ShowInTaskbar = true;
                     window.ResizeMode = ResizeMode.NoResize;
                 }


### PR DESCRIPTION
Removed Modal views being Topmost. Activate the window only in cases where it was not always activated.

Fixes #442 