### PR TITLE
Add feature to run webapp in container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine
+RUN apk add nodejs npm
+
+WORKDIR /app
+ENV HOME=/app
+COPY . /app/
+RUN sed -i '/Sidekick.Wpf/,+1d' Sidekick.sln && dotnet build
+
+WORKDIR /app/src/Sidekick.Web
+VOLUME /app/src/Sidekick.Web/sidekick
+EXPOSE 5000
+ENTRYPOINT ["/usr/bin/dotnet"]
+CMD ["bin/Debug/net8.0/Sidekick.dll", "--urls", "http://*:5000"]

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ We accept most PR and ideas. If you want a feature included, create an issue and
 #### Implementation Notes
 The application is a web application that is running inside a WebView2 provided by WPF. Development can also be done using the Web project.
 
+#### Running webapp in docker
+1. Clone the repository
+2. Build an image using `docker build --tag sidekickpoe:latest --file Dockerfile .`
+3. Run it with `docker run -p 5000:5000 -v ./sidekick-data:/app/src/Sidekick.Web/sidekick sidekickpoe:latest`
+4. Access through http://localhost:5000
+
 ## Notice
 This product isn't affiliated with or endorsed by Grinding Gear Games in any way.
 


### PR DESCRIPTION
This is a small feature that allows to run webapp in a docker container which can be useful on linux machines (this is exactly howI use Sidekick).

Idea provided by [this comment](https://github.com/Sidekick-Poe/Sidekick/issues/328#issuecomment-2600893199) by @solacelost