### PR TITLE
Adjust the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ RUN apk add nodejs npm
 WORKDIR /app
 ENV HOME=/app
 COPY . /app/
-RUN dotnet build /p:Configuration="Linux-Release"
+RUN sed -i '/Sidekick.Wpf/,+1d' Sidekick.sln
+RUN dotnet build --configuration Release
 
 WORKDIR /app/src/Sidekick.Web
 VOLUME /app/src/Sidekick.Web/sidekick
 EXPOSE 5000
 ENTRYPOINT ["/usr/bin/dotnet"]
-CMD ["bin/Linux-Release/net8.0/Sidekick.dll", "--urls", "http://*:5000"]
+CMD ["bin/Release/net8.0/Sidekick.dll", "--urls", "http://*:5000"]


### PR DESCRIPTION
changes to Dockerfile to remove the WPF project (it's not able to be built in a Linux container), run normal `dotnet build` without specifying Linux Release, run the web .dll.

I have tested that this works on a Linux machine through the browser. 