### PR TITLE
Enable CA1822 in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,6 +72,7 @@ dotnet_diagnostic.bc42356.severity = warning
 dotnet_diagnostic.bc42358.severity = warning
 dotnet_diagnostic.bc42504.severity = warning
 dotnet_diagnostic.bc42505.severity = warning
+dotnet_diagnostic.ca1822.severity = error
 dotnet_diagnostic.ca2252.severity = error
 dotnet_diagnostic.cs0067.severity = warning
 dotnet_diagnostic.cs0078.severity = warning

--- a/src/Sidekick.Apis.GitHub/GitHubClient.cs
+++ b/src/Sidekick.Apis.GitHub/GitHubClient.cs
@@ -124,7 +124,7 @@ public class GitHubClient
         return githubReleaseList?.FirstOrDefault(x => !x.Prerelease);
     }
 
-    private Version? GetCurrentVersion()
+    private static Version? GetCurrentVersion()
     {
         return AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName()).FirstOrDefault(x => x.Name == "Sidekick")?.Version;
     }

--- a/src/Sidekick.Apis.Poe/Modifiers/InvariantModifierProvider.cs
+++ b/src/Sidekick.Apis.Poe/Modifiers/InvariantModifierProvider.cs
@@ -116,7 +116,7 @@ public class InvariantModifierProvider
         }
     }
 
-    private bool IsCategory(ApiCategory apiCategory, string? key)
+    private static bool IsCategory(ApiCategory apiCategory, string? key)
     {
         var first = apiCategory.Entries.FirstOrDefault();
         return first?.Id.Split('.')[0] == key;

--- a/src/Sidekick.Apis.Poe/Parser/Modifiers/ModifierParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Modifiers/ModifierParser.cs
@@ -157,7 +157,7 @@ public class ModifierParser
         }
     }
 
-    private void ParseModifierValues(ModifierLine modifierLine, IEnumerable<ModifierPattern> patterns)
+    private static void ParseModifierValues(ModifierLine modifierLine, IEnumerable<ModifierPattern> patterns)
     {
         var pattern = patterns.FirstOrDefault();
         if (pattern == null)

--- a/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
@@ -138,7 +138,7 @@ public class PropertyParser
         return results;
     }
 
-    private void CleanUpSeparatorFilters(List<BooleanPropertyFilter> results)
+    private static void CleanUpSeparatorFilters(List<BooleanPropertyFilter> results)
     {
         // Remove leading SeparatorProperty filters
         while (results.Count > 0 && results[0].Definition is SeparatorProperty)

--- a/src/Sidekick.Apis.Poe/Stash/StashService.cs
+++ b/src/Sidekick.Apis.Poe/Stash/StashService.cs
@@ -35,7 +35,7 @@ public class StashService(
         }
     }
 
-    private void FillStashTabs(
+    private static void FillStashTabs(
         string leagueId,
         List<StashTab> list,
         List<ApiStashTab> apiStashTabs)

--- a/src/Sidekick.Apis.Poe/Trade/Requests/Filters/StatFilters.cs
+++ b/src/Sidekick.Apis.Poe/Trade/Requests/Filters/StatFilters.cs
@@ -4,5 +4,5 @@ public class StatFilters
 {
     public string? Id { get; set; }
     public StatFilterValue? Value { get; set; }
-    public bool Disabled => false;
+    public static bool Disabled => false;
 }

--- a/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
@@ -164,7 +164,7 @@ public class TradeSearchService
         throw new ApiErrorException();
     }
 
-    private SearchFilterOption? GetCategoryFilter(string? itemCategory)
+    private static SearchFilterOption? GetCategoryFilter(string? itemCategory)
     {
         if (string.IsNullOrEmpty(itemCategory))
         {
@@ -174,7 +174,7 @@ public class TradeSearchService
         return new SearchFilterOption(itemCategory);
     }
 
-    private StatFilterGroup? GetAndStats(List<ModifierFilter>? modifierFilters, List<PseudoModifierFilter>? pseudoFilters)
+    private static StatFilterGroup? GetAndStats(List<ModifierFilter>? modifierFilters, List<PseudoModifierFilter>? pseudoFilters)
     {
         var andGroup = new StatFilterGroup()
         {
@@ -227,7 +227,7 @@ public class TradeSearchService
         return andGroup;
     }
 
-    private StatFilterGroup? GetCountStats(List<ModifierFilter>? modifierFilters)
+    private static StatFilterGroup? GetCountStats(List<ModifierFilter>? modifierFilters)
     {
         var countGroup = new StatFilterGroup()
         {
@@ -281,7 +281,7 @@ public class TradeSearchService
         return countGroup;
     }
 
-    private List<StatFilterGroup> GetWeightedSumStats(List<PseudoModifierFilter>? pseudoFilters)
+    private static List<StatFilterGroup> GetWeightedSumStats(List<PseudoModifierFilter>? pseudoFilters)
     {
         if (pseudoFilters == null)
         {

--- a/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
@@ -142,7 +142,7 @@ public class PoeNinjaClient : IPoeNinjaClient
     /// <summary>
     /// Get Poe.ninja's league uri from POE's API league id.
     /// </summary>
-    private string GetLeagueUri(string? leagueId)
+    private static string GetLeagueUri(string? leagueId)
     {
         leagueId = leagueId.GetUrlSlugForLeague();
         return leagueId switch
@@ -154,7 +154,7 @@ public class PoeNinjaClient : IPoeNinjaClient
         };
     }
 
-    private string GetCacheKey(ItemType itemType) => $"PoeNinja_{itemType}";
+    private static string GetCacheKey(ItemType itemType) => $"PoeNinja_{itemType}";
 
     private async Task ClearCacheIfExpired()
     {
@@ -307,7 +307,7 @@ public class PoeNinjaClient : IPoeNinjaClient
         return [];
     }
 
-    private IEnumerable<ItemType> GetApiItemTypes(Category category)
+    private static IEnumerable<ItemType> GetApiItemTypes(Category category)
     {
         switch (category)
         {

--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -174,7 +174,7 @@ public partial class Initialization : SidekickView
         });
     }
 
-    private string? GetVersion()
+    private static string? GetVersion()
     {
         var version = AppDomain.CurrentDomain.GetAssemblies().Select(x => x.GetName()).FirstOrDefault(x => x.Name == "Sidekick")?.Version;
         return version?.ToString();

--- a/src/Sidekick.Common.Platform/Interprocess/InterprocessMessaging.cs
+++ b/src/Sidekick.Common.Platform/Interprocess/InterprocessMessaging.cs
@@ -6,7 +6,7 @@ public class InterprocessMessaging
 
     public static event Action<string>? OnMessageReceived;
 
-    public void ReceiveMessage(string message)
+    public static void ReceiveMessage(string message)
     {
         OnMessageReceived?.Invoke(message);
     }

--- a/src/Sidekick.Common.Platform/Interprocess/InterprocessService.cs
+++ b/src/Sidekick.Common.Platform/Interprocess/InterprocessService.cs
@@ -47,7 +47,7 @@ public class InterprocessService : IInterprocessService, IDisposable
         logger.LogDebug("[Interprocess] Sending message to other application instance. {0}", message);
         using var pipeClient = new PipeClient<InterprocessMessaging>(new NetJsonPipeSerializer(), InterprocessMessaging.Pipename);
         await pipeClient.ConnectAsync();
-        await pipeClient.InvokeAsync(x => x.ReceiveMessage(message));
+        await pipeClient.InvokeAsync(x => InterprocessMessaging.ReceiveMessage(message));
         logger.LogDebug("[Interprocess] Message sent.");
     }
 

--- a/src/Sidekick.Common.Platform/Keyboards/KeyboardProvider.cs
+++ b/src/Sidekick.Common.Platform/Keyboards/KeyboardProvider.cs
@@ -316,7 +316,7 @@ public class KeyboardProvider(
         return Task.CompletedTask;
     }
 
-    private (List<KeyCode> Modifiers, List<KeyCode> Keys) FetchKeys(string stroke)
+    private static (List<KeyCode> Modifiers, List<KeyCode> Keys) FetchKeys(string stroke)
     {
         var keyCodes = new List<KeyCode>();
         var modifierCodes = new List<KeyCode>();

--- a/src/Sidekick.Common/Game/GameLogs/GameLogProvider.cs
+++ b/src/Sidekick.Common/Game/GameLogs/GameLogProvider.cs
@@ -60,7 +60,7 @@ public class GameLogProvider(
     /// </summary>
     /// <param name="stream">The stream.</param>
     /// <returns>The current line of the stream position</returns>
-    private string GetLine(Stream stream)
+    private static string GetLine(Stream stream)
     {
         // while we have not yet reached start of file, read bytes backwards until '\n' byte is hit
         var lineLength = 0;

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -240,7 +240,7 @@ public class SettingsService(
         OnSettingsChanged?.Invoke();
     }
 
-    private string? GetStringValue(object? value)
+    private static string? GetStringValue(object? value)
     {
         if (value == null)
         {

--- a/src/Sidekick.Wpf/App.xaml.cs
+++ b/src/Sidekick.Wpf/App.xaml.cs
@@ -106,12 +106,12 @@ public partial class App
         }
     }
 
-    private bool HasApplicationStartedUsingSidekickProtocol(StartupEventArgs e)
+    private static bool HasApplicationStartedUsingSidekickProtocol(StartupEventArgs e)
     {
         return e.Args.Length > 0 && e.Args[0].ToUpper().StartsWith("SIDEKICK://");
     }
 
-    private void ShutdownAndExit()
+    private static void ShutdownAndExit()
     {
         Current.Dispatcher.Invoke(() =>
         {
@@ -120,7 +120,7 @@ public partial class App
         Environment.Exit(0);
     }
 
-    private ServiceProvider GetServiceProvider()
+    private static ServiceProvider GetServiceProvider()
     {
         var services = new ServiceCollection();
 
@@ -198,7 +198,7 @@ public partial class App
         };
     }
 
-    private void DisableWindowsTheme()
+    private static void DisableWindowsTheme()
     {
         // Disable Aero theme text rendering
         RenderOptions.ProcessRenderMode = RenderMode.SoftwareOnly;

--- a/tests/Sidekick.Apis.Poe.Tests/Poe1/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe1/ParserFixture.cs
@@ -63,7 +63,7 @@ public class ParserFixture : IAsyncLifetime
         InvariantModifierProvider = ctx.Services.GetRequiredService<IInvariantModifierProvider>();
     }
 
-    private async Task Initialize(IServiceProvider serviceProvider)
+    private static async Task Initialize(IServiceProvider serviceProvider)
     {
         var cache = serviceProvider.GetRequiredService<ICacheProvider>();
         await cache.Clear();

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
@@ -63,7 +63,7 @@ public class ParserFixture : IAsyncLifetime
         InvariantModifierProvider = ctx.Services.GetRequiredService<IInvariantModifierProvider>();
     }
 
-    private async Task Initialize(IServiceProvider serviceProvider)
+    private static async Task Initialize(IServiceProvider serviceProvider)
     {
         var cache = serviceProvider.GetRequiredService<ICacheProvider>();
         await cache.Clear();


### PR DESCRIPTION
I figured I'd enable this as an error for the solution, that way if you run `dotnet format` it will automatically make each method `static` that is able to be static. 

Some more information on it: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1822