### PR TITLE
Add docker compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,4 @@ MigrationBackup/
 .idea/
 
 github_secret*
+sidekick-data/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ The application is a web application that is running inside a WebView2 provided 
 3. Run it with `docker run -p 5000:5000 -v ./sidekick-data:/app/src/Sidekick.Web/sidekick sidekickpoe:latest`
 4. Access through http://localhost:5000
 
+#### Running webapp with docker compose (requires [Docker Compose](https://docs.docker.com/compose/install/))
+1. Clone the repository
+2. Build and run the project with `docker compose up` 
+3. Access through http://localhost:5000
+
 ## Notice
 This product isn't affiliated with or endorsed by Grinding Gear Games in any way.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  sidekick:
+    image: sidekickpoe:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 5000:5000
+    volumes:
+      - ./sidekick-data:/app/src/Sidekick.Web/sidekick


### PR DESCRIPTION
So here's a suggestion on adding a docker compose file, where a folder called `/sidekick-data` is also ignored as it's mounted as a permanent volume to the container.

Also added the info to the README.