### PR TITLE
add GetOrCreateTypeFilters()

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
@@ -55,7 +55,7 @@ public class GemLevelProperty
         {
             case GameType.PathOfExile: searchFilters.GetOrCreateMiscFilters().Filters.GemLevel = new StatFilterValue(intFilter); break;
 
-            case GameType.PathOfExile2 when apiInvariantItemProvider.UncutGemIds.Contains(item.Header.ApiItemId ?? string.Empty): searchFilters.TypeFilters.Filters.ItemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2 when apiInvariantItemProvider.UncutGemIds.Contains(item.Header.ApiItemId ?? string.Empty): searchFilters.GetOrCreateTypeFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
 
             case GameType.PathOfExile2: searchFilters.GetOrCreateMiscFilters().Filters.GemLevel = new StatFilterValue(intFilter); break;
         }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
@@ -47,7 +47,7 @@ public class ItemLevelProperty(IGameLanguageProvider gameLanguageProvider, GameT
         {
             case GameType.PathOfExile: searchFilters.GetOrCreateMiscFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
 
-            case GameType.PathOfExile2: searchFilters.TypeFilters.Filters.ItemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.GetOrCreateTypeFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Trade/Requests/Filters/SearchFilters.cs
+++ b/src/Sidekick.Apis.Poe/Trade/Requests/Filters/SearchFilters.cs
@@ -5,7 +5,9 @@ namespace Sidekick.Apis.Poe.Trade.Requests.Filters;
 public class SearchFilters
 {
     [JsonPropertyName("type_filters")]
-    public TypeFilterGroup TypeFilters { get; set; } = new();
+    public TypeFilterGroup? TypeFilters { get; set; }
+
+    public TypeFilterGroup GetOrCreateTypeFilters() => TypeFilters ??= new();
 
     [JsonPropertyName("trade_filters")]
     public TradeFilterGroup? TradeFilters { get; set; }

--- a/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
@@ -66,7 +66,7 @@ public class TradeSearchService
             }
             else if (propertyFilters.ClassFilterApplied)
             {
-                query.Filters.TypeFilters.Filters.Category = GetCategoryFilter(item.Header.ItemCategory);
+                query.Filters.GetOrCreateTypeFilters().Filters.Category = GetCategoryFilter(item.Header.ItemCategory);
             }
 
             if (item.Header.Category == Category.ItemisedMonster && !string.IsNullOrEmpty(itemApiNameToUse))
@@ -77,7 +77,7 @@ public class TradeSearchService
             else if (item.Header.Rarity == Rarity.Unique && !string.IsNullOrEmpty(itemApiNameToUse))
             {
                 query.Name = itemApiNameToUse;
-                query.Filters.TypeFilters.Filters.Rarity = new SearchFilterOption("Unique");
+                query.Filters.GetOrCreateTypeFilters().Filters.Rarity = new SearchFilterOption("Unique");
             }
             else if (propertyFilters?.RarityFilterApplied ?? false)
             {
@@ -90,11 +90,11 @@ public class TradeSearchService
                     _ => "nonunique",
                 };
 
-                query.Filters.TypeFilters.Filters.Rarity = new SearchFilterOption(rarity);
+                query.Filters.GetOrCreateTypeFilters().Filters.Rarity = new SearchFilterOption(rarity);
             }
             else
             {
-                query.Filters.TypeFilters.Filters.Rarity = new SearchFilterOption("nonunique");
+                query.Filters.GetOrCreateTypeFilters().Filters.Rarity = new SearchFilterOption("nonunique");
             }
 
             var currency = item.Header.Game == GameType.PathOfExile ? await settingsService.GetString(SettingKeys.PriceCheckCurrency) : await settingsService.GetString(SettingKeys.PriceCheckCurrencyPoE2);


### PR DESCRIPTION
I continued the pattern already used in `SearchFilters.cs`. 

And I checked the request sent in the networks tab when trying out the issue described in https://github.com/Sidekick-Poe/Sidekick/issues/509 and noticed that `type_filters` wasn't always sent so I figured it should follow the same optional pattern as the other ones. :)