### PR TITLE
Refactor SidekickConfiguration to use static members

### DIFF
--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Exceptions;
 using Sidekick.Common.Initialization;
@@ -24,9 +23,6 @@ public partial class Initialization : SidekickView
 
     [Inject]
     private IApplicationService ApplicationService { get; set; } = null!;
-
-    [Inject]
-    private IOptions<SidekickConfiguration> Configuration { get; set; } = null!;
 
     [Inject]
     private IServiceProvider ServiceProvider { get; set; } = null!;
@@ -68,7 +64,7 @@ public partial class Initialization : SidekickView
         try
         {
             Completed = 0;
-            Count = Configuration.Value.InitializableServices.Count;
+            Count = SidekickConfiguration.InitializableServices.Count;
             var version = ApplicationService.GetVersion();
             var previousVersion = await SettingsService.GetString(SettingKeys.Version);
             if (version != previousVersion)
@@ -80,7 +76,7 @@ public partial class Initialization : SidekickView
             // Report initial progress
             await ReportProgress();
 
-            var services = Configuration.Value.InitializableServices.Select(serviceType =>
+            var services = SidekickConfiguration.InitializableServices.Select(serviceType =>
                 {
                     var service = ServiceProvider.GetRequiredService(serviceType);
                     return service as IInitializableService;

--- a/src/Sidekick.Common.Blazor/Main.razor
+++ b/src/Sidekick.Common.Blazor/Main.razor
@@ -1,12 +1,9 @@
-@using Microsoft.Extensions.Options;
-@using Sidekick.Common.Ui.Views
 @using MudBlazor.Utilities
 @using MudBlazor
-@inject IOptions<SidekickConfiguration> Configuration;
 @inject IViewLocator ViewLocator
 
 <AppWrapper>
-    <Router AppAssembly="@typeof(Main).Assembly" AdditionalAssemblies="Configuration.Value.Modules">
+    <Router AppAssembly="@typeof(Main).Assembly" AdditionalAssemblies="SidekickConfiguration.Modules">
         <Found Context="routeData">
             <RouteView RouteData="@routeData"/>
         </Found>

--- a/src/Sidekick.Common.Platform/Keyboards/KeyboardProvider.cs
+++ b/src/Sidekick.Common.Platform/Keyboards/KeyboardProvider.cs
@@ -3,7 +3,6 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using SharpHook;
 using SharpHook.Logging;
 using SharpHook.Native;
@@ -13,7 +12,6 @@ namespace Sidekick.Common.Platform.Keyboards;
 
 public class KeyboardProvider(
     ILogger<KeyboardProvider> logger,
-    IOptions<SidekickConfiguration> configuration,
     IServiceProvider serviceProvider,
     IProcessProvider processProvider) : IKeyboardProvider, IDisposable
 {
@@ -162,7 +160,7 @@ public class KeyboardProvider(
     {
         // Initialize keybindings
         KeybindHandlers.Clear();
-        foreach (var keybindType in configuration.Value.Keybinds)
+        foreach (var keybindType in SidekickConfiguration.Keybinds)
         {
             var keybindHandler = (KeybindHandler)serviceProvider.GetRequiredService(keybindType);
             KeybindHandlers.Add(keybindHandler);

--- a/src/Sidekick.Common.Platform/StartupExtensions.cs
+++ b/src/Sidekick.Common.Platform/StartupExtensions.cs
@@ -35,14 +35,11 @@ public static class StartupExtensions
         services.AddSidekickInitializableService<IKeyboardProvider, KeyboardProvider>();
         services.AddSingleton<IGameLogProvider, GameLogProvider>();
 
-        services.Configure<SidekickConfiguration>(o =>
+        foreach (var keybind in SidekickConfiguration.Keybinds)
         {
-            foreach (var keybind in o.Keybinds)
-            {
-                services.TryAddSingleton(keybind);
-                services.AddSidekickInitializableService(keybind, keybind);
-            }
-        });
+            SidekickConfiguration.InitializableServices.Add(keybind);
+            services.AddSingleton(keybind);
+        }
 
         return services;
     }

--- a/src/Sidekick.Common/ServiceCollectionExtensions.cs
+++ b/src/Sidekick.Common/ServiceCollectionExtensions.cs
@@ -1,6 +1,5 @@
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Serilog;
 using Serilog.Events;
 using Sidekick.Common.Browser;
@@ -75,25 +74,8 @@ public static class ServiceCollectionExtensions
         this IServiceCollection services,
         Assembly assembly)
     {
-        services.Configure<SidekickConfiguration>(
-            o =>
-            {
-                o.Modules.Add(assembly);
-            });
-
+        SidekickConfiguration.Modules.Add(assembly);
         return services;
-    }
-
-    /// <summary>
-    ///     Adds an initializable service to the application.
-    /// </summary>
-    /// <param name="services">The service collection to add an initializable service.</param>
-    /// <typeparam name="TService">The type of service to add to the application.</typeparam>
-    /// <returns>The service collection.</returns>
-    public static IServiceCollection AddSidekickInitializableService<TService>(this IServiceCollection services)
-        where TService : class, IInitializableService
-    {
-        return services.AddSidekickInitializableService<TService, TService>();
     }
 
     /// <summary>
@@ -107,34 +89,8 @@ public static class ServiceCollectionExtensions
         where TService : class, IInitializableService
         where TImplementation : class, TService
     {
-        services.TryAddSingleton<TService, TImplementation>();
-
-        services.Configure<SidekickConfiguration>(
-            o =>
-            {
-                o.InitializableServices.Add(typeof(TService));
-            });
-
-        return services;
-    }
-
-    /// <summary>
-    ///     Adds an initializable service to the application.
-    /// </summary>
-    /// <param name="services">The service collection to add an initializable service.</param>
-    /// <param name="service">The type of service to add to the application.</param>
-    /// <param name="implementation">The type of the implementation of the service.</param>
-    /// <returns>The service collection.</returns>
-    public static IServiceCollection AddSidekickInitializableService(this IServiceCollection services, Type service, Type implementation)
-    {
-        services.TryAddSingleton(service, implementation);
-
-        services.Configure<SidekickConfiguration>(
-            o =>
-            {
-                o.InitializableServices.Add(service);
-            });
-
+        services.AddSingleton<TService, TImplementation>();
+        SidekickConfiguration.InitializableServices.Add(typeof(TService));
         return services;
     }
 
@@ -147,13 +103,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddSidekickKeybind<TKeybindHandler>(this IServiceCollection services)
         where TKeybindHandler : KeybindHandler
     {
-        services.AddSidekickInitializableService<TKeybindHandler>();
-        services.Configure<SidekickConfiguration>(
-            o =>
-            {
-                o.Keybinds.Add(typeof(TKeybindHandler));
-            });
-
+        SidekickConfiguration.Keybinds.Add(typeof(TKeybindHandler));
         return services;
     }
 }

--- a/src/Sidekick.Common/SidekickConfiguration.cs
+++ b/src/Sidekick.Common/SidekickConfiguration.cs
@@ -6,20 +6,20 @@ namespace Sidekick.Common;
 /// <summary>
 ///     Configuration class for the application.
 /// </summary>
-public class SidekickConfiguration
+public static class SidekickConfiguration
 {
     /// <summary>
     ///     Gets or sets a list of initializable services.
     /// </summary>
-    public List<Type> InitializableServices { get; } = new();
+    public static List<Type> InitializableServices { get; } = new();
 
     /// <summary>
     ///     Gets or sets a list of modules.
     /// </summary>
-    public List<Assembly> Modules { get; } = new();
+    public static List<Assembly> Modules { get; } = new();
 
     /// <summary>
     ///     The list of keybinds handled by this application
     /// </summary>
-    public List<Type> Keybinds { get; } = new();
+    public static List<Type> Keybinds { get; } = new();
 }

--- a/src/Sidekick.Modules.Development/Sidekick.Modules.Development.csproj
+++ b/src/Sidekick.Modules.Development/Sidekick.Modules.Development.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <ProjectReference Include="..\Sidekick.Apis.Poe\Sidekick.Apis.Poe.csproj" />
     <ProjectReference Include="..\Sidekick.Common.Blazor\Sidekick.Common.Blazor.csproj" />
-    <ProjectReference Include="..\Sidekick.Common.Platform\Sidekick.Common.Platform.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Sidekick.Modules.Wealth/Sidekick.Modules.Wealth.csproj
+++ b/src/Sidekick.Modules.Wealth/Sidekick.Modules.Wealth.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\Sidekick.Apis.Poe\Sidekick.Apis.Poe.csproj" />
     <ProjectReference Include="..\Sidekick.Common.Blazor\Sidekick.Common.Blazor.csproj" />
     <ProjectReference Include="..\Sidekick.Common.Database\Sidekick.Common.Database.csproj" />
-    <ProjectReference Include="..\Sidekick.Common.Platform\Sidekick.Common.Platform.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Sidekick.Web/Sidekick.Web.csproj
+++ b/src/Sidekick.Web/Sidekick.Web.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Sidekick.Common.Interprocess\Sidekick.Common.Interprocess.csproj" />
-    <ProjectReference Include="..\Sidekick.Common.Platform\Sidekick.Common.Platform.csproj" />
     <ProjectReference Include="..\Sidekick.Common.Updater\Sidekick.Common.Updater.csproj" />
     <ProjectReference Include="..\Sidekick.Modules.Chat\Sidekick.Modules.Chat.csproj" />
     <ProjectReference Include="..\Sidekick.Modules.Development\Sidekick.Modules.Development.csproj" />

--- a/tests/Sidekick.Apis.Poe.Tests/Poe1/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe1/ParserFixture.cs
@@ -1,7 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.PoeNinja;
 using Sidekick.Apis.PoeWiki;
@@ -64,9 +63,8 @@ public class ParserFixture : IAsyncLifetime
         var cache = serviceProvider.GetRequiredService<ICacheProvider>();
         await cache.Clear();
 
-        var configuration = serviceProvider.GetRequiredService<IOptions<SidekickConfiguration>>();
         var logger = serviceProvider.GetRequiredService<ILogger<ParserFixture>>();
-        foreach (var serviceType in configuration.Value.InitializableServices)
+        foreach (var serviceType in SidekickConfiguration.InitializableServices)
         {
             var service = serviceProvider.GetRequiredService(serviceType);
             if (service is not IInitializableService initializableService)

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
@@ -1,8 +1,6 @@
 using Bunit;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using Sidekick.Apis.Poe.Filters;
 using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.Poe.Parser.Properties;
@@ -80,9 +78,8 @@ public class ParserFixture : IAsyncLifetime
         var cache = serviceProvider.GetRequiredService<ICacheProvider>();
         await cache.Clear();
 
-        var configuration = serviceProvider.GetRequiredService<IOptions<SidekickConfiguration>>();
         var logger = serviceProvider.GetRequiredService<ILogger<ParserFixture>>();
-        foreach (var serviceType in configuration.Value.InitializableServices)
+        foreach (var serviceType in SidekickConfiguration.InitializableServices)
         {
             var service = serviceProvider.GetRequiredService(serviceType);
             if (service is not IInitializableService initializableService)


### PR DESCRIPTION
Replaced instance-based configuration in `SidekickConfiguration` with static members. This change simplifies initialization and usage by directly referencing static properties. Removed unused dependencies on `IOptions<T>` throughout the codebase for cleaner and more efficient service setup.

IOptions had problems during the initialization where we couldn't add services from the Configure() call. We want to add services conditionally and that proved tricky.