### PR TITLE
Closing the window should now focus properly.

### DIFF
--- a/src/Sidekick.Wpf/MainWindow.xaml.cs
+++ b/src/Sidekick.Wpf/MainWindow.xaml.cs
@@ -141,6 +141,15 @@ public partial class MainWindow
         DragMove();
     }
 
+    /// <summary>
+    /// Temporarily deactivates the current window.
+    /// This is typically used to manage focus-related issues when the main window should lose focus.
+    /// </summary>
+    /// <remarks>
+    /// We use this method typically right before we close the window. Sidekick had an issue for the longest time,
+    /// where closing the overlay would focus a random window instead of giving the focus back to the game.
+    /// This method ensures the window loses focus before closing. The way this is done is by creating a temporary window and giving focus to that.
+    /// Windows magic.</remarks>
     public void Deactivate()
     {
         // Check if the window is still valid and focused

--- a/src/Sidekick.Wpf/MainWindow.xaml.cs
+++ b/src/Sidekick.Wpf/MainWindow.xaml.cs
@@ -66,7 +66,6 @@ public partial class MainWindow
         base.OnClosing(e);
 
         MaximizeHelper.RemoveHook(this);
-        ClearFocusOnClosing();
 
         if (isClosing || !IsVisible || ResizeMode != ResizeMode.CanResize && ResizeMode != ResizeMode.CanResizeWithGrip || WindowState == WindowState.Maximized)
         {
@@ -142,53 +141,33 @@ public partial class MainWindow
         DragMove();
     }
 
-    #region Code to make sure the focus is lost correctly when the window is closed.
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetForegroundWindow();
-
-    [DllImport("user32.dll")]
-    private static extern bool SetForegroundWindow(IntPtr hWnd);
-
-    private IntPtr previousWindowHandle;
-
-    private void ClearFocusOnClosing()
+    public void Deactivate()
     {
-        // Get the handle for the foreground window (current active window)
-        var foregroundWindow = GetForegroundWindow();
-
-        // Check if the window currently active belongs to our application
-        if (new WindowInteropHelper(this).Handle != foregroundWindow)
+        // Check if the window is still valid and focused
+        if (!IsActive)
         {
-            // Just in case, set the focus back to the application
-            SetForegroundWindow(new WindowInteropHelper(this).Handle);
+            return;
         }
 
-        // Get the handle of the currently focused window (likely the WPF window itself)
-        previousWindowHandle = GetForegroundWindow();
-
-        // Remove focus explicitly from WebView
-        Keyboard.ClearFocus();
-
-        // Optionally, set focus to a parent element or another default element
-        FocusManager.SetFocusedElement(this, this);
-
-        // Ensure the WebView is removed from the visual tree
-        WebView.Visibility = Visibility.Collapsed;
-    }
-
-    protected override void OnClosed(EventArgs e)
-    {
-        base.OnClosed(e);
-
-        // Explicitly set focus back to the previous window
-        if (previousWindowHandle != IntPtr.Zero)
+        // Create a hidden dummy window to take focus temporarily
+        var helperWindow = new Window
         {
-            SetForegroundWindow(previousWindowHandle);
-        }
-    }
+            Width = 1,
+            Height = 1,
+            ShowInTaskbar = false,
+            WindowStyle = WindowStyle.None,
+            AllowsTransparency = true,
+            Background = null,
+            Opacity = 0
+        };
 
-    #endregion
+        // Show the helper window to take focus
+        helperWindow.Show();
+
+        // Set focus to the dummy window before closing it
+        helperWindow.Activate();
+        helperWindow.Close();
+    }
 
     protected override void OnSourceInitialized(EventArgs e)
     {

--- a/src/Sidekick.Wpf/Services/WpfViewLocator.cs
+++ b/src/Sidekick.Wpf/Services/WpfViewLocator.cs
@@ -215,6 +215,7 @@ public class WpfViewLocator : IViewLocator
         {
             try
             {
+                window.Deactivate();
                 window.Close();
                 Windows.Remove(window);
                 GC.Collect();


### PR DESCRIPTION
Replaces the `ClearFocusOnClosing` method with a streamlined `Deactivate` method to handle focus and cleanup more effectively. This simplifies code by removing unnecessary focus management logic and introducing a lightweight helper window for proper focus handling during deactivation.

Fixes #394 
Fixes #410 