### PR TITLE
Removed legacy launcher support

### DIFF
--- a/src/Sidekick.Common.Updater/Components/Update.ko.resx
+++ b/src/Sidekick.Common.Updater/Components/Update.ko.resx
@@ -126,12 +126,6 @@
   <data name="Checking_For_Updates" xml:space="preserve">
     <value>업데이트가 있는지 확인중입니다</value>
   </data>
-  <data name="NewLauncher" xml:space="preserve">
-      <value>새로운 런처를 이용할 수 있습니다!</value>
-  </data>
-  <data name="NewLauncherText" xml:space="preserve">
-      <value>새롭고 더 좋아진 런쳐를 이용할 수 있습니다. 웹사이트를 열어서 다운로드하세요. 이 버전은 삭제하셔도 됩니다.</value>
-  </data>
   <data name="Continue" xml:space="preserve">
       <value>사이트 열기</value>
   </data>

--- a/src/Sidekick.Common.Updater/Components/Update.razor
+++ b/src/Sidekick.Common.Updater/Components/Update.razor
@@ -19,14 +19,6 @@
         {
             <AlertError>@Resources["Update_Cant_Download"]</AlertError>
         }
-        else if (NewLauncher)
-        {
-            <AppContainer>
-                <Heading3 Class="mb-2 text-center">@Resources["NewLauncher"]</Heading3>
-                <TextBase
-                    Class="text-center">@Resources["NewLauncherText"]</TextBase>
-            </AppContainer>
-        }
         else if (UpdateInfo == null)
         {
             <AppContainer>
@@ -70,24 +62,15 @@
 
     <BottomContent>
         <div class="px-3 py-2 flex justify-center gap-2">
-            @if (NewLauncher)
+            <ButtonSecondary OnClick="Exit">@Resources["Exit"]</ButtonSecondary>
+            @if (!Updating)
             {
-                <ButtonSecondary OnClick="Exit">@Resources["Exit"]</ButtonSecondary>
-                <ButtonSecondary OnClick="Continue">@Resources["Continue"]</ButtonSecondary>
-                <ButtonPrimary OnClick="OpenWebsite">@Resources["Open_Website"]</ButtonPrimary>
+                <ButtonSecondary OnClick="Continue">@Resources["Skip"]</ButtonSecondary>
             }
-            else
-            {
-                <ButtonSecondary OnClick="Exit">@Resources["Exit"]</ButtonSecondary>
-                @if (!Updating)
-                {
-                    <ButtonSecondary OnClick="Continue">@Resources["Skip"]</ButtonSecondary>
-                }
 
-                @if (UpdateInfo != null && !Updating)
-                {
-                    <ButtonPrimary OnClick="Download">@Resources["Update"]</ButtonPrimary>
-                }
+            @if (UpdateInfo != null && !Updating)
+            {
+                <ButtonPrimary OnClick="Download">@Resources["Update"]</ButtonPrimary>
             }
         </div>
     </BottomContent>
@@ -102,8 +85,6 @@
 @code {
 
     private bool Error { get; set; }
-
-    private bool NewLauncher { get; set; }
 
     private bool Updating { get; set; }
 

--- a/src/Sidekick.Common.Updater/Components/Update.razor
+++ b/src/Sidekick.Common.Updater/Components/Update.razor
@@ -129,11 +129,13 @@
             return;
         }
 
-        try
+        if (AutoUpdater.IsUpdaterInstalled())
         {
             UpdateInfo = await AutoUpdater.CheckForUpdates();
-            if (UpdateInfo == null)
+
+            if (UpdateInfo is null)
             {
+                // There's no available updates
                 NavigationManager.NavigateTo("/setup");
             }
             else
@@ -141,18 +143,10 @@
                 CurrentView.SetSize(height: 500);
             }
         }
-        catch (Exception ex)
+        else
         {
-            if (ex.Message == "Cannot perform this operation in an application which is not installed.")
-            {
-                NewLauncher = true;
-            }
-            else
-            {
-                Logger.LogError(ex.Message);
-                Error = true;
-                StateHasChanged();
-            }
+            Logger.LogWarning("[AutoUpdater] UpdateManager is not installed.");
+            NavigationManager.NavigateTo("/setup");
         }
     }
 

--- a/src/Sidekick.Common.Updater/Components/Update.resx
+++ b/src/Sidekick.Common.Updater/Components/Update.resx
@@ -135,12 +135,6 @@
   <data name="Exit" xml:space="preserve">
       <value>Exit</value>
   </data>
-  <data name="NewLauncher" xml:space="preserve">
-      <value>New launcher available!</value>
-  </data>
-  <data name="NewLauncherText" xml:space="preserve">
-      <value>A new and improved launcher is available. Open the website to grab it. You can uninstall this version.</value>
-  </data>
   <data name="Changelog" xml:space="preserve">
       <value>Changelog</value>
   </data>

--- a/src/Sidekick.Common.Updater/IAutoUpdater.cs
+++ b/src/Sidekick.Common.Updater/IAutoUpdater.cs
@@ -7,6 +7,8 @@ namespace Sidekick.Common.Updater;
 /// </summary>
 public interface IAutoUpdater
 {
+    bool IsUpdaterInstalled();
+
     /// <summary>
     /// Checks for available updates for the application.
     /// </summary>


### PR DESCRIPTION
If I run the Sidekick.Wpf project with `dotnet run` I get this screen upon startup:

![dotnetrun](https://github.com/user-attachments/assets/7eecfaa8-124b-4ca6-86c9-f2986524bb39)

And if I run with `docker compose up` I see this initially: 

![browser](https://github.com/user-attachments/assets/a3ce7675-12f4-4d28-b6c8-0e84f0725478)

I guess none of these are desired to be shown here - so I'm just suggestion a fix here to amend that. 

The fix is just removing what was in the catch-block. Otherwise I just saw that there was a helper method from UpdateManager that could be used instead of catching the exception:

![ensureInstalled](https://github.com/user-attachments/assets/018df2f7-5974-42e6-b6ba-c38c1d319102)
