### PR TITLE
Add editorconfig rule for forbidding unused using directives

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -282,6 +282,7 @@ dotnet_diagnostic.fs1183.severity = warning
 dotnet_diagnostic.fs3218.severity = warning
 dotnet_diagnostic.fs3390.severity = warning
 dotnet_diagnostic.fs3520.severity = warning
+dotnet_diagnostic.ide0005.severity = error
 dotnet_diagnostic.wme006.severity = warning
 dotnet_naming_rule.constants_rule.import_to_resharper = as_predefined
 dotnet_naming_rule.constants_rule.resharper_style = AaBb, aaBb

--- a/src/Sidekick.Apis.GitHub/IGitHubClient.cs
+++ b/src/Sidekick.Apis.GitHub/IGitHubClient.cs
@@ -1,5 +1,4 @@
 using Sidekick.Apis.GitHub.Models;
-using Sidekick.Common.Initialization;
 
 namespace Sidekick.Apis.GitHub;
 

--- a/src/Sidekick.Apis.Poe/CloudFlare/CloudflareService.cs
+++ b/src/Sidekick.Apis.Poe/CloudFlare/CloudflareService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sidekick.Common.Settings;
 

--- a/src/Sidekick.Apis.Poe/Filters/FilterProvider.cs
+++ b/src/Sidekick.Apis.Poe/Filters/FilterProvider.cs
@@ -49,9 +49,9 @@ public class FilterProvider
             .First(x => x.Id == "indexed").Option!.Options;
     }
 
-    public string? GetPriceOption(string? price) => 
+    public string? GetPriceOption(string? price) =>
         TradePriceOptions.SingleOrDefault(x => x.Id == price)?.Id;
 
-    public string? GetTradeIndexedOption(string? id) => 
+    public string? GetTradeIndexedOption(string? id) =>
         TradeIndexedOptions.SingleOrDefault(x => x.Id == id)?.Id;
 }

--- a/src/Sidekick.Apis.Poe/Items/ApiItemConstants.cs
+++ b/src/Sidekick.Apis.Poe/Items/ApiItemConstants.cs
@@ -1,4 +1,4 @@
-﻿using Sidekick.Common.Game.Items;
+using Sidekick.Common.Game.Items;
 
 namespace Sidekick.Apis.Poe.Items;
 

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Localization;
 using Sidekick.Apis.Poe.Localization;

--- a/src/Sidekick.Apis.Poe/Parser/Properties/IPropertyParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/IPropertyParser.cs
@@ -1,5 +1,4 @@
 using Sidekick.Apis.Poe.Parser.Properties.Filters;
-using Sidekick.Apis.Poe.Trade.Models;
 using Sidekick.Apis.Poe.Trade.Requests.Filters;
 using Sidekick.Common.Game.Items;
 using Sidekick.Common.Initialization;

--- a/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
@@ -26,20 +26,6 @@ public class PropertyParser
 
     private List<PropertyDefinition> Definitions { get; set; } = new();
 
-    private Regex? MapTier { get; set; }
-
-    private Regex? ItemQuantity { get; set; }
-
-    private Regex? ItemRarity { get; set; }
-
-    private Regex? MonsterPackSize { get; set; }
-
-    private Regex? Blighted { get; set; }
-
-    private Regex? BlightRavaged { get; set; }
-
-    private Regex? AreaLevel { get; set; }
-
     public async Task Initialize()
     {
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);
@@ -85,14 +71,6 @@ public class PropertyParser
         {
             definition.Initialize();
         }
-
-        MapTier = gameLanguageProvider.Language.DescriptionMapTier.ToRegexIntCapture();
-        AreaLevel = gameLanguageProvider.Language.DescriptionAreaLevel.ToRegexIntCapture();
-        ItemQuantity = gameLanguageProvider.Language.DescriptionItemQuantity.ToRegexIntCapture();
-        ItemRarity = gameLanguageProvider.Language.DescriptionItemRarity.ToRegexIntCapture();
-        MonsterPackSize = gameLanguageProvider.Language.DescriptionMonsterPackSize.ToRegexIntCapture();
-        Blighted = gameLanguageProvider.Language.AffixBlighted.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
-        BlightRavaged = gameLanguageProvider.Language.AffixBlightRavaged.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
     }
 
     public ItemProperties Parse(ParsingItem parsingItem)

--- a/src/Sidekick.Apis.Poe/StartupExtensions.cs
+++ b/src/Sidekick.Apis.Poe/StartupExtensions.cs
@@ -16,7 +16,6 @@ using Sidekick.Apis.Poe.Parser.AdditionalInformation;
 using Sidekick.Apis.Poe.Parser.Headers;
 using Sidekick.Apis.Poe.Parser.Modifiers;
 using Sidekick.Apis.Poe.Parser.Properties;
-using Sidekick.Apis.Poe.Parser.Properties.Filters;
 using Sidekick.Apis.Poe.Parser.Pseudo;
 using Sidekick.Apis.Poe.Parser.Requirements;
 using Sidekick.Apis.Poe.Parser.Sockets;

--- a/src/Sidekick.Apis.PoeWiki/QueryStringHelper.cs
+++ b/src/Sidekick.Apis.PoeWiki/QueryStringHelper.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using System.Web;
 
 namespace Sidekick.Apis.PoeWiki;

--- a/src/Sidekick.Common.Blazor/ServiceCollectionExtensions.cs
+++ b/src/Sidekick.Common.Blazor/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Common.Blazor.Initialization;
 using Sidekick.Common.Blazor.Settings;
-using Sidekick.Common.Ui;
 using Sidekick.Common.Ui.Dialogs;
 using Sidekick.Common.Ui.Views;
 

--- a/src/Sidekick.Common.Platform/StartupExtensions.cs
+++ b/src/Sidekick.Common.Platform/StartupExtensions.cs
@@ -1,6 +1,5 @@
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Sidekick.Common.Platform.Clipboard;
 using Sidekick.Common.Platform.GameLogs;
 using Sidekick.Common.Platform.Keyboards;

--- a/src/Sidekick.Common.Platform/Windows/DllImport/EventLoop.cs
+++ b/src/Sidekick.Common.Platform/Windows/DllImport/EventLoop.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-
 namespace Sidekick.Common.Platform.Windows.DllImport;
 
 internal static class EventLoop

--- a/src/Sidekick.Common.Platform/Windows/DllImport/User32.cs
+++ b/src/Sidekick.Common.Platform/Windows/DllImport/User32.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 using System.Text;
 

--- a/src/Sidekick.Common.Platform/Windows/DllImport/WinMessage.cs
+++ b/src/Sidekick.Common.Platform/Windows/DllImport/WinMessage.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Runtime.InteropServices;
 
 namespace Sidekick.Common.Platform.Windows.DllImport;

--- a/src/Sidekick.Common.Ui/Views/CurrentView.cs
+++ b/src/Sidekick.Common.Ui/Views/CurrentView.cs
@@ -6,7 +6,7 @@ namespace Sidekick.Common.Ui.Views;
 /// <summary>
 /// Interface to manage views
 /// </summary>
-public class CurrentView: ICurrentView, IDisposable
+public class CurrentView : ICurrentView, IDisposable
 {
     private readonly IViewLocator viewLocator;
     private readonly NavigationManager navigationManager;

--- a/src/Sidekick.Common.Updater/DebugLocator.cs
+++ b/src/Sidekick.Common.Updater/DebugLocator.cs
@@ -1,4 +1,4 @@
-﻿using NuGet.Versioning;
+using NuGet.Versioning;
 using Velopack;
 using Velopack.Locators;
 
@@ -24,7 +24,7 @@ public class DebugLocator : IVelopackLocator
 
     public string? UpdateExePath => null;
 
-    public SemanticVersion CurrentlyInstalledVersion => new (1, 0, 0);
+    public SemanticVersion CurrentlyInstalledVersion => new(1, 0, 0);
 
     public string? ThisExeRelativePath => null;
 

--- a/src/Sidekick.Common/SidekickConfiguration.cs
+++ b/src/Sidekick.Common/SidekickConfiguration.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Sidekick.Common.Settings;
 
 namespace Sidekick.Common;
 

--- a/src/Sidekick.Modules.Wealth/StartupExtensions.cs
+++ b/src/Sidekick.Modules.Wealth/StartupExtensions.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Common;
-using Sidekick.Modules.Wealth.Keybinds;
 
 namespace Sidekick.Modules.Wealth;
 

--- a/src/Sidekick.Modules.Wealth/WealthParser.cs
+++ b/src/Sidekick.Modules.Wealth/WealthParser.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
-using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Clients.Exceptions;
 using Sidekick.Apis.Poe.Stash;
 using Sidekick.Apis.Poe.Stash.Models;

--- a/src/Sidekick.Web/Services/WebApplicationService.cs
+++ b/src/Sidekick.Web/Services/WebApplicationService.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Sidekick.Common.Platform;
 
 namespace Sidekick.Web.Services;

--- a/src/Sidekick.Web/Services/WebViewLocator.cs
+++ b/src/Sidekick.Web/Services/WebViewLocator.cs
@@ -1,4 +1,4 @@
-﻿using Sidekick.Common.Ui.Views;
+using Sidekick.Common.Ui.Views;
 
 namespace Sidekick.Web.Services;
 

--- a/src/Sidekick.Wpf/MainWindow.xaml.cs
+++ b/src/Sidekick.Wpf/MainWindow.xaml.cs
@@ -1,10 +1,8 @@
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Net;
-using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Input;
-using System.Windows.Interop;
 using System.Windows.Media;
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Common.Ui.Views;

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
@@ -2,7 +2,6 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
-using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.Poe.Trade;
 using Xunit;
 


### PR DESCRIPTION
I found some unused code in `src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs` so I figured I could clean that up.

Also I'd like to suggest to add a rule for forbidding unused using directives. That way they can be removed when you run `dotnet format` or your IDE will probably clean it up for you.