### PR TITLE
Improved structure of PropertyDefinition classes

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AreaLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AreaLevelProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class AreaLevelProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionAreaLevel.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Sanctum, Category.Logbook, Category.Contract, Category.Map];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionAreaLevel.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ArmourProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ArmourProperty.cs
@@ -13,14 +13,9 @@ public class ArmourProperty
     GameType game
 ) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionArmour.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionArmour.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AttacksPerSecondProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AttacksPerSecondProperty.cs
@@ -9,14 +9,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class AttacksPerSecondProperty(IGameLanguageProvider gameLanguageProvider, GameType game) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionAttacksPerSecond.ToRegexDoubleCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Weapon];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionAttacksPerSecond.ToRegexDoubleCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightRavagedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightRavagedProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class BlightRavagedProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.AffixBlightRavaged.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
 
     public override List<Category> ValidCategories { get; } = [Category.Map];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.AffixBlightRavaged.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightedProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class BlightedProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.AffixBlighted.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
 
     public override List<Category> ValidCategories { get; } = [Category.Map];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.AffixBlighted.ToRegexAffix(gameLanguageProvider.Language.AffixSuperior);
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlockChanceProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlockChanceProperty.cs
@@ -9,21 +9,11 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class BlockChanceProperty(IGameLanguageProvider gameLanguageProvider, GameType game) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = game is GameType.PathOfExile
+        ? gameLanguageProvider.Language.DescriptionChanceToBlock.ToRegexIntCapture()
+        : gameLanguageProvider.Language.DescriptionBlockChance.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour];
-
-    public override void Initialize()
-    {
-        if (game == GameType.PathOfExile)
-        {
-            Pattern = gameLanguageProvider.Language.DescriptionChanceToBlock.ToRegexIntCapture();
-        }
-        else
-        {
-            Pattern = gameLanguageProvider.Language.DescriptionBlockChance.ToRegexIntCapture();
-        }
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CorruptedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CorruptedProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class CorruptedProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionCorrupted.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Map, Category.Contract, Category.Jewel, Category.Flask, Category.Gem];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionCorrupted.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CriticalHitChanceProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CriticalHitChanceProperty.cs
@@ -9,21 +9,11 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class CriticalHitChanceProperty(IGameLanguageProvider gameLanguageProvider, GameType game) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = game is GameType.PathOfExile
+        ? gameLanguageProvider.Language.DescriptionCriticalStrikeChance.ToRegexDoubleCapture()
+        : gameLanguageProvider.Language.DescriptionCriticalHitChance.ToRegexDoubleCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Weapon];
-
-    public override void Initialize()
-    {
-        if (game == GameType.PathOfExile)
-        {
-            Pattern = gameLanguageProvider.Language.DescriptionCriticalStrikeChance.ToRegexDoubleCapture();
-        }
-        else
-        {
-            Pattern = gameLanguageProvider.Language.DescriptionCriticalHitChance.ToRegexDoubleCapture();
-        }
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CrusaderProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CrusaderProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class CrusaderProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceCrusader.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceCrusader.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ElderProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ElderProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class ElderProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceElder.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceElder.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EnergyShieldProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EnergyShieldProperty.cs
@@ -13,20 +13,14 @@ public class EnergyShieldProperty
     GameType game
 ) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionEnergyShield.ToRegexIntCapture();  
 
-    private Regex? AlternatePattern { get; set; }
+    private Regex? AlternatePattern { get; } = 
+        !string.IsNullOrEmpty(gameLanguageProvider.Language.DescriptionEnergyShieldAlternate)
+            ? gameLanguageProvider.Language.DescriptionEnergyShieldAlternate.ToRegexIntCapture()
+            : null;
 
     public override List<Category> ValidCategories { get; } = [Category.Armour];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionEnergyShield.ToRegexIntCapture();
-        if (!string.IsNullOrEmpty(gameLanguageProvider.Language.DescriptionEnergyShieldAlternate))
-        {
-            AlternatePattern = gameLanguageProvider.Language.DescriptionEnergyShieldAlternate.ToRegexIntCapture();
-        }
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EvasionRatingProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EvasionRatingProperty.cs
@@ -9,14 +9,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class EvasionRatingProperty(IGameLanguageProvider gameLanguageProvider, GameType game) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionEvasion.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionEvasion.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
@@ -15,14 +15,9 @@ public class GemLevelProperty
     IApiInvariantItemProvider apiInvariantItemProvider
 ) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionLevel.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Gem];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionLevel.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/HunterProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/HunterProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class HunterProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceHunter.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceHunter.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
@@ -9,14 +9,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class ItemLevelProperty(IGameLanguageProvider gameLanguageProvider, GameType game) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionItemLevel.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Flask, Category.Jewel, Category.Accessory, Category.Map, Category.Contract, Category.Sanctum, Category.Logbook];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionItemLevel.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemQuantityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemQuantityProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class ItemQuantityProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionItemQuantity.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Map, Category.Contract];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionItemQuantity.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemRarityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemRarityProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class ItemRarityProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionItemRarity.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Map, Category.Contract];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionItemRarity.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MapTierProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MapTierProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class MapTierProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionMapTier.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Map];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionMapTier.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MonsterPackSizeProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MonsterPackSizeProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class MonsterPackSizeProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionMonsterPackSize.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Map, Category.Contract];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionMonsterPackSize.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/QualityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/QualityProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class QualityProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionQuality.ToRegexIntCapture();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Flask, Category.Gem, Category.Map];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionQuality.ToRegexIntCapture();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/RedeemerProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/RedeemerProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class RedeemerProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceRedeemer.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceRedeemer.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/SeparatorProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/SeparatorProperty.cs
@@ -10,10 +10,6 @@ public class SeparatorProperty() : PropertyDefinition
 
     public override List<Category> ValidCategories { get; } = [];
 
-    public override void Initialize()
-    {
-    }
-
     public override BooleanPropertyFilter? GetFilter(Item item, double normalizeValue)
     {
         return new BooleanPropertyFilter(this)

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ShaperProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ShaperProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class ShaperProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceShaper.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceShaper.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/UnidentifiedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/UnidentifiedProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class UnidentifiedProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.DescriptionUnidentified.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Flask, Category.Map, Category.Contract, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.DescriptionUnidentified.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WarlordProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WarlordProperty.cs
@@ -8,14 +8,9 @@ namespace Sidekick.Apis.Poe.Parser.Properties.Definitions;
 
 public class WarlordProperty(IGameLanguageProvider gameLanguageProvider) : PropertyDefinition
 {
-    private Regex? Pattern { get; set; }
+    private Regex Pattern { get; } = gameLanguageProvider.Language.InfluenceWarlord.ToRegexLine();
 
     public override List<Category> ValidCategories { get; } = [Category.Armour, Category.Weapon, Category.Accessory, Category.Jewel];
-
-    public override void Initialize()
-    {
-        Pattern = gameLanguageProvider.Language.InfluenceWarlord.ToRegexLine();
-    }
 
     public override void Parse(ItemProperties itemProperties, ParsingItem parsingItem)
     {

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
@@ -21,10 +21,6 @@ public class WeaponDamageProperty
 {
     public override List<Category> ValidCategories { get; } = [Category.Weapon];
 
-    public override void Initialize()
-    {
-    }
-
     public override void ParseAfterModifiers(ItemProperties properties, ParsingItem parsingItem, List<ModifierLine> modifierLines)
     {
         var propertyBlock = parsingItem.Blocks[1];

--- a/src/Sidekick.Apis.Poe/Parser/Properties/PropertyDefinition.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/PropertyDefinition.cs
@@ -10,8 +10,6 @@ public abstract class PropertyDefinition
 {
     public abstract List<Category> ValidCategories { get; }
 
-    public abstract void Initialize();
-
     public virtual void Parse(ItemProperties itemProperties, ParsingItem parsingItem) { }
 
     public virtual void ParseAfterModifiers(ItemProperties itemProperties, ParsingItem parsingItem, List<ModifierLine> modifierLines) { }
@@ -22,19 +20,11 @@ public abstract class PropertyDefinition
 
     public abstract void PrepareTradeRequest(SearchFilters searchFilters, Item item, BooleanPropertyFilter filter);
 
-    protected static bool GetBool(Regex? pattern, ParsingItem parsingItem)
-    {
-        if (pattern == null)
-        {
-            return false;
-        }
+    protected static bool GetBool(Regex pattern, ParsingItem parsingItem) => parsingItem.TryParseRegex(pattern, out _);
 
-        return parsingItem.TryParseRegex(pattern, out _);
-    }
-
-    protected static int GetInt(Regex? pattern, ParsingItem parsingItem)
+    protected static int GetInt(Regex pattern, ParsingItem parsingItem)
     {
-        if (pattern != null && parsingItem.TryParseRegex(pattern, out var match) && int.TryParse(match.Groups[1].Value, out var result))
+        if (parsingItem.TryParseRegex(pattern, out var match) && int.TryParse(match.Groups[1].Value, out var result))
         {
             return result;
         }
@@ -42,9 +32,9 @@ public abstract class PropertyDefinition
         return 0;
     }
 
-    protected static int GetInt(Regex? pattern, ParsingBlock parsingBlock)
+    protected static int GetInt(Regex pattern, ParsingBlock parsingBlock)
     {
-        if (pattern != null && parsingBlock.TryParseRegex(pattern, out var match) && int.TryParse(match.Groups[1].Value, out var result))
+        if (parsingBlock.TryParseRegex(pattern, out var match) && int.TryParse(match.Groups[1].Value, out var result))
         {
             return result;
         }
@@ -52,9 +42,9 @@ public abstract class PropertyDefinition
         return 0;
     }
 
-    protected static double GetDouble(Regex? pattern, ParsingBlock parsingBlock)
+    protected static double GetDouble(Regex pattern, ParsingBlock parsingBlock)
     {
-        if (pattern == null || !parsingBlock.TryParseRegex(pattern, out var match))
+        if (!parsingBlock.TryParseRegex(pattern, out var match))
         {
             return 0;
         }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/PropertyParser.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.Localization;
 using Sidekick.Apis.Poe.Items;
 using Sidekick.Apis.Poe.Localization;
@@ -66,11 +65,6 @@ public class PropertyParser
             new RedeemerProperty(gameLanguageProvider),
             new WarlordProperty(gameLanguageProvider),
         ]);
-
-        foreach (var definition in Definitions)
-        {
-            definition.Initialize();
-        }
     }
 
     public ItemProperties Parse(ParsingItem parsingItem)


### PR DESCRIPTION
I was looking into initializations and found that the abstract method `Initialize` on `PropertyDefinition` wasn't needed and the nullability of `Pattern` could be removed.