### PR TITLE
Centralize JsonSerialization and JsonSerializationOptions

### DIFF
--- a/src/Sidekick.Apis.GitHub/GitHubClient.cs
+++ b/src/Sidekick.Apis.GitHub/GitHubClient.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using Sidekick.Apis.GitHub.Api;
 using Sidekick.Apis.GitHub.Models;
 using Sidekick.Common;
+using Sidekick.Common.Extensions;
 
 namespace Sidekick.Apis.GitHub;
 

--- a/src/Sidekick.Apis.GitHub/GitHubClient.cs
+++ b/src/Sidekick.Apis.GitHub/GitHubClient.cs
@@ -1,11 +1,10 @@
 using System.Diagnostics;
 using System.Net.Http.Headers;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.GitHub.Api;
 using Sidekick.Apis.GitHub.Models;
+using Sidekick.Common;
 
 namespace Sidekick.Apis.GitHub;
 
@@ -16,7 +15,6 @@ public class GitHubClient
 ) : IGitHubClient
 {
     private DateTimeOffset? LastUpdateCheck { get; set; }
-
     private GitHubRelease? LatestRelease { get; set; }
 
     /// <inheritdoc />
@@ -110,12 +108,8 @@ public class GitHubClient
             return [];
         }
 
-        return await JsonSerializer.DeserializeAsync<Release[]>(utf8Json: await listResponse.Content.ReadAsStreamAsync(),
-                                                                options: new JsonSerializerOptions
-                                                                {
-                                                                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                                                                    PropertyNameCaseInsensitive = true,
-                                                                });
+        var res = await listResponse.Content.ReadAsStreamAsync();
+        return await res.FromJsonToAsync<Release[]>(SerializationOptions.WithoutEnumConverterOptions);
     }
 
     private async Task<Release?> GetLatestApiRelease()

--- a/src/Sidekick.Apis.Poe/Authentication/AuthenticationService.cs
+++ b/src/Sidekick.Apis.Poe/Authentication/AuthenticationService.cs
@@ -1,8 +1,8 @@
 using System.Security.Cryptography;
 using System.Text;
 using Sidekick.Apis.Poe.Authentication.Models;
-using Sidekick.Common;
 using Sidekick.Common.Browser;
+using Sidekick.Common.Extensions;
 using Sidekick.Common.Platform.Interprocess;
 using Sidekick.Common.Settings;
 

--- a/src/Sidekick.Apis.Poe/Authentication/AuthenticationService.cs
+++ b/src/Sidekick.Apis.Poe/Authentication/AuthenticationService.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
 using Sidekick.Apis.Poe.Authentication.Models;
+using Sidekick.Common;
 using Sidekick.Common.Browser;
 using Sidekick.Common.Platform.Interprocess;
 using Sidekick.Common.Settings;
@@ -171,7 +171,7 @@ internal class AuthenticationService : IAuthenticationService, IDisposable
         }
 
         var responseContent = await response.Content.ReadAsStreamAsync();
-        var result = await JsonSerializer.DeserializeAsync<Oauth2TokenResponse>(responseContent);
+        var result = await responseContent.FromJsonToAsync<Oauth2TokenResponse>();
 
         if (result == null || result.access_token == null)
         {

--- a/src/Sidekick.Apis.Poe/Clients/IPoeTradeClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/IPoeTradeClient.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Common.Game;
 using Sidekick.Common.Game.Languages;
@@ -7,7 +6,5 @@ namespace Sidekick.Apis.Poe.Clients;
 
 public interface IPoeTradeClient
 {
-    JsonSerializerOptions Options { get; }
-
     Task<FetchResult<TReturn>> Fetch<TReturn>(GameType game, IGameLanguage language, string path);
 }

--- a/src/Sidekick.Apis.Poe/Clients/PoeApiClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeApiClient.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients.Exceptions;
 using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Common;
+using Sidekick.Common.Extensions;
 using Sidekick.Common.Settings;
 
 namespace Sidekick.Apis.Poe.Clients;

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
@@ -1,8 +1,7 @@
 using System.Net;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients.Models;
+using Sidekick.Common;
 using Sidekick.Common.Game;
 using Sidekick.Common.Game.Languages;
 
@@ -12,13 +11,6 @@ public class PoeTradeClient(
     ILogger<PoeTradeClient> logger,
     IHttpClientFactory httpClientFactory) : IPoeTradeClient
 {
-    public JsonSerializerOptions Options { get; } = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-    };
-
     public async Task<FetchResult<TReturn>> Fetch<TReturn>(GameType game, IGameLanguage language, string path)
     {
         var name = typeof(TReturn).Name;
@@ -46,7 +38,7 @@ public class PoeTradeClient(
 
             var content = await response.Content.ReadAsStreamAsync();
 
-            var result = await JsonSerializer.DeserializeAsync<FetchResult<TReturn>>(content, Options);
+            var result = await content.FromJsonToAsync<FetchResult<TReturn>>(SerializationOptions.WithEnumConverterOptions);
             if (result == null)
             {
                 throw new Exception($"[Trade Client] Could not understand the API response.");

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
@@ -2,6 +2,7 @@ using System.Net;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Common;
+using Sidekick.Common.Extensions;
 using Sidekick.Common.Game;
 using Sidekick.Common.Game.Languages;
 

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
@@ -1,9 +1,8 @@
 using System.Net;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Apis.Poe.CloudFlare;
+using Sidekick.Common;
 using Sidekick.Common.Exceptions;
 using Sidekick.Common.Game.Languages;
 using Sidekick.Common.Settings;
@@ -140,13 +139,8 @@ public class PoeTradeHandler
     {
         try
         {
-            var options = new JsonSerializerOptions()
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            };
             var content = await response.Content.ReadAsStreamAsync();
-            return await JsonSerializer.DeserializeAsync<ApiErrorResponse>(content, options);
+            return await content.FromJsonToAsync<ApiErrorResponse>(SerializationOptions.WithoutEnumConverterOptions);
         }
         catch (Exception)
         {

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
@@ -4,6 +4,7 @@ using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Apis.Poe.CloudFlare;
 using Sidekick.Common;
 using Sidekick.Common.Exceptions;
+using Sidekick.Common.Extensions;
 using Sidekick.Common.Game.Languages;
 using Sidekick.Common.Settings;
 

--- a/src/Sidekick.Apis.PoePriceInfo/PoePriceInfoClient.cs
+++ b/src/Sidekick.Apis.PoePriceInfo/PoePriceInfoClient.cs
@@ -1,8 +1,8 @@
 using System.Text;
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.PoePriceInfo.Api;
 using Sidekick.Apis.PoePriceInfo.Models;
+using Sidekick.Common;
 using Sidekick.Common.Extensions;
 using Sidekick.Common.Game.Items;
 using Sidekick.Common.Settings;
@@ -14,11 +14,6 @@ public class PoePriceInfoClient(
     ILogger<PoePriceInfoClient> logger,
     IHttpClientFactory httpClientFactory) : IPoePriceInfoClient
 {
-    private readonly JsonSerializerOptions options = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
-    };
-
     private HttpClient GetHttpClient()
     {
         var client = httpClientFactory.CreateClient();
@@ -43,7 +38,7 @@ public class PoePriceInfoClient(
             using var client = GetHttpClient();
             var response = await client.GetAsync("?l=" + leagueId.GetUrlSlugForLeague() + "&i=" + encodedItem);
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<PriceInfoResult>(content, options);
+            var result = await content.FromJsonToAsync<PriceInfoResult>(SerializationOptions.CamelCaseNaming);
 
             if (result == null)
             {

--- a/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
+++ b/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
@@ -6,6 +6,7 @@ using Sidekick.Apis.PoeWiki.Models;
 using Sidekick.Common;
 using Sidekick.Common.Browser;
 using Sidekick.Common.Cache;
+using Sidekick.Common.Extensions;
 using Sidekick.Common.Game.Items;
 
 namespace Sidekick.Apis.PoeWiki;

--- a/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
+++ b/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
@@ -1,9 +1,9 @@
-using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.PoeWiki.Api;
 using Sidekick.Apis.PoeWiki.Extensions;
 using Sidekick.Apis.PoeWiki.Models;
+using Sidekick.Common;
 using Sidekick.Common.Browser;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Game.Items;
@@ -22,12 +22,6 @@ public class PoeWikiClient
     ICacheProvider cacheProvider
 ) : IPoeWikiClient
 {
-    private readonly JsonSerializerOptions options = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        PropertyNameCaseInsensitive = true
-    };
-
     private const string PoeWikiBaseUri = "https://www.poewiki.net/";
     private const string PoeWikiSubUrl = "w/index.php?search=";
 
@@ -137,7 +131,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<MapResult>>(content, options);
+            var result = await content.FromJsonToAsync<CargoQueryResult<MapResult>>(SerializationOptions.CaseInsensitiveOptions);
             return result?.CargoQuery.Select(x => x.Title).FirstOrDefault();
         }
         catch (Exception e)
@@ -165,7 +159,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<BossResult>>(content, options);
+            var result = await content.FromJsonToAsync<CargoQueryResult<BossResult>>(SerializationOptions.CaseInsensitiveOptions);
             if (result == null)
             {
                 return null;
@@ -210,7 +204,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<CargoQueryResult<ItemResult>>(content, options);
+            var result = content.FromJsonTo<CargoQueryResult<ItemResult>>(SerializationOptions.CaseInsensitiveOptions);
             if (result == null)
             {
                 return null;
@@ -257,7 +251,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemIdResult>>(content, options);
+            var result = await content.FromJsonToAsync<CargoQueryResult<ItemIdResult>>(SerializationOptions.CaseInsensitiveOptions);
             if (result == null)
             {
                 return null;
@@ -301,7 +295,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemNameMetadataIdResult>>(content, options);
+            var result = await content.FromJsonToAsync<CargoQueryResult<ItemNameMetadataIdResult>>(SerializationOptions.CaseInsensitiveOptions);
             if (result == null)
             {
                 return null;

--- a/src/Sidekick.Common.Blazor/Setup/Setup.razor
+++ b/src/Sidekick.Common.Blazor/Setup/Setup.razor
@@ -83,7 +83,7 @@
         try
         {
             var leagues = await LeagueProvider.GetList(false);
-            var apiLeaguesHash = JsonSerializer.Serialize(leagues).GetDeterministicHashCode();
+            var apiLeaguesHash = leagues.ToJson().GetDeterministicHashCode();
             var settingsLeaguesHash = await SettingsService.GetInt(SettingKeys.LeaguesHash);
             if (apiLeaguesHash != settingsLeaguesHash)
             {
@@ -137,7 +137,7 @@
             return;
         }
 
-        var apiLeaguesHash = JsonSerializer.Serialize(leagues).GetDeterministicHashCode();
+        var apiLeaguesHash = leagues.ToJson().GetDeterministicHashCode();
         await SettingsService.Set(SettingKeys.LeaguesHash, apiLeaguesHash);
 
         CurrentView.SetSize(height: 220);

--- a/src/Sidekick.Common/Cache/CacheProvider.cs
+++ b/src/Sidekick.Common/Cache/CacheProvider.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Microsoft.Extensions.Logging;
 
 namespace Sidekick.Common.Cache;
@@ -26,7 +25,7 @@ public class CacheProvider(ILogger<CacheProvider> logger) : ICacheProvider
         await using var stream = File.OpenRead(fileName);
         try
         {
-            var value = await JsonSerializer.DeserializeAsync<TModel>(stream);
+            var value = await stream.FromJsonToAsync<TModel>();
             if (value == null) return null;
 
             var valid = cacheValidator.Invoke(value);
@@ -56,7 +55,7 @@ public class CacheProvider(ILogger<CacheProvider> logger) : ICacheProvider
             }
 
             await using var stream = File.Create(fileName);
-            await JsonSerializer.SerializeAsync(stream, data);
+            await stream.ToJson(data);
         }
         catch (IOException exception)
         {

--- a/src/Sidekick.Common/Cache/CacheProvider.cs
+++ b/src/Sidekick.Common/Cache/CacheProvider.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Logging;
+using Sidekick.Common.Extensions;
 
 namespace Sidekick.Common.Cache;
 

--- a/src/Sidekick.Common/Extensions/SerializerExtensions.cs
+++ b/src/Sidekick.Common/Extensions/SerializerExtensions.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
 
-namespace Sidekick.Common;
+namespace Sidekick.Common.Extensions;
 
-public static class Serialization
+public static class SerializerExtensions
 {
     public static string ToJson<T>(this T value, JsonSerializerOptions? jsonSerializerOptions = null) =>
         JsonSerializer.Serialize(value, options: jsonSerializerOptions);

--- a/src/Sidekick.Common/Serialization.cs
+++ b/src/Sidekick.Common/Serialization.cs
@@ -1,0 +1,18 @@
+using System.Text.Json;
+
+namespace Sidekick.Common;
+
+public static class Serialization
+{
+    public static string ToJson<T>(this T value, JsonSerializerOptions? jsonSerializerOptions = null) =>
+        JsonSerializer.Serialize(value, options: jsonSerializerOptions);
+
+    public static async Task ToJson<T>(this FileStream stream, T data) =>
+        await JsonSerializer.SerializeAsync(stream, data);
+
+    public static T? FromJsonTo<T>(this string value, JsonSerializerOptions? jsonSerializerOptions = null) =>
+        JsonSerializer.Deserialize<T>(value, options: jsonSerializerOptions);
+
+    public static async Task<T?> FromJsonToAsync<T>(this Stream stream, JsonSerializerOptions? jsonSerializerOptions = null) => 
+        await JsonSerializer.DeserializeAsync<T>(stream, options: jsonSerializerOptions);
+}

--- a/src/Sidekick.Common/SerializationOptions.cs
+++ b/src/Sidekick.Common/SerializationOptions.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Sidekick.Common;
+
+public static class SerializationOptions
+{
+    public static readonly JsonSerializerOptions CamelCaseNaming = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    public static readonly JsonSerializerOptions CaseInsensitiveOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true
+    };
+
+    public static readonly JsonSerializerOptions WithoutEnumConverterOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
+    public static readonly JsonSerializerOptions WithEnumConverterOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
+}

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Sidekick.Common.Database;
 using Sidekick.Common.Database.Tables;
 using Sidekick.Common.Enums;
+using Sidekick.Common.Extensions;
 
 namespace Sidekick.Common.Settings;
 

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Text.Json;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Sidekick.Common.Database;
@@ -117,7 +116,7 @@ public class SettingsService(
         {
             try
             {
-                return JsonSerializer.Deserialize<TValue>(dbSetting.Value ?? string.Empty);
+                return (dbSetting.Value ?? string.Empty).FromJsonTo<TValue>();
             }
             catch (Exception e)
             {
@@ -254,7 +253,7 @@ public class SettingsService(
             DateTimeOffset x => x.ToString(),
             Enum x => x.GetValueAttribute(),
             string x => x,
-            _ => JsonSerializer.Serialize(value),
+            _ => value.ToJson(),
         };
     }
 }

--- a/src/Sidekick.Wpf/Cloudflare/CloudflareWindow.xaml.cs
+++ b/src/Sidekick.Wpf/Cloudflare/CloudflareWindow.xaml.cs
@@ -6,7 +6,7 @@ using System.Windows.Media;
 using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 using Sidekick.Apis.Poe.CloudFlare;
-using Sidekick.Common;
+using Sidekick.Common.Extensions;
 using Sidekick.Wpf.Helpers;
 using Application = System.Windows.Application;
 

--- a/src/Sidekick.Wpf/Cloudflare/CloudflareWindow.xaml.cs
+++ b/src/Sidekick.Wpf/Cloudflare/CloudflareWindow.xaml.cs
@@ -6,6 +6,7 @@ using System.Windows.Media;
 using Microsoft.Extensions.Logging;
 using Microsoft.Web.WebView2.Core;
 using Sidekick.Apis.Poe.CloudFlare;
+using Sidekick.Common;
 using Sidekick.Wpf.Helpers;
 using Application = System.Windows.Application;
 
@@ -163,7 +164,7 @@ public partial class CloudflareWindow
             logger.LogInformation("[CloudflareWindow] DevTools Network Parameters \n" + json);
 
             // Deserialize the JSON to extract request headers
-            var parameters = JsonSerializer.Deserialize<DevToolsParameters>(json, JsonSerializerOptions.Default);
+            var parameters = json.FromJsonTo<DevToolsParameters>(JsonSerializerOptions.Default);
             if (parameters?.Request != null)
             {
                 logger.LogInformation("[CloudflareWindow] Deserialized " + parameters.Request.Headers.Count + " headers");

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
@@ -1,7 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Filters;
 using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.Poe.Parser.Properties;
@@ -29,7 +28,6 @@ public class ParserFixture : IAsyncLifetime
     public ITradeFilterService TradeFilterService { get; private set; } = null!;
     public ISettingsService SettingsService { get; private set; } = null!;
     public IModifierProvider ModifierProvider { get; private set; } = null!;
-    public IPoeTradeClient PoeTradeClient { get; private set; } = null!;
     private TestContext TestContext { get; set; } = null!;
 
     public async Task InitializeAsync()
@@ -67,7 +65,6 @@ public class ParserFixture : IAsyncLifetime
         FilterProvider = TestContext.Services.GetRequiredService<IFilterProvider>();
         TradeFilterService = TestContext.Services.GetRequiredService<ITradeFilterService>();
         ModifierProvider = TestContext.Services.GetRequiredService<IModifierProvider>();
-        PoeTradeClient = TestContext.Services.GetRequiredService<IPoeTradeClient>();
     }
 
     public Task DisposeAsync()

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Sidekick.Apis.Poe.Trade;
 using Sidekick.Common;
+using Sidekick.Common.Extensions;
 using Xunit;
 
 namespace Sidekick.Apis.Poe.Tests.Poe2.Query;


### PR DESCRIPTION
So here's a bit of refactoring, the primary thing is to reuse JsonSerializerOptions (since that's recommended) I moved all instances of it to `SerializerOptions.cs`. It might be possible to combine them into fewer, but I haven't done that here.

Also, for making serialization a bit tidier I also created `Serialization` which contains 
* `ToJson()` and 
* `FromJsonTo<T>` 
As static helper method that can be used anywhere it's needed.

This way, if you ever want to replace the serialization it's easier to do that too.

So with these changes, I also converted some classes to use primary constructors.