### PR TITLE
Make JsonSerializerOptions static

### DIFF
--- a/src/Sidekick.Apis.GitHub/GitHubClient.cs
+++ b/src/Sidekick.Apis.GitHub/GitHubClient.cs
@@ -16,8 +16,12 @@ public class GitHubClient
 ) : IGitHubClient
 {
     private DateTimeOffset? LastUpdateCheck { get; set; }
-
     private GitHubRelease? LatestRelease { get; set; }
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
 
     /// <inheritdoc />
     public async Task<GitHubRelease> GetLatestRelease()
@@ -110,12 +114,8 @@ public class GitHubClient
             return [];
         }
 
-        return await JsonSerializer.DeserializeAsync<Release[]>(utf8Json: await listResponse.Content.ReadAsStreamAsync(),
-                                                                options: new JsonSerializerOptions
-                                                                {
-                                                                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-                                                                    PropertyNameCaseInsensitive = true,
-                                                                });
+        var content = await listResponse.Content.ReadAsStreamAsync();
+        return await JsonSerializer.DeserializeAsync<Release[]>(content, JsonSerializerOptions);
     }
 
     private async Task<Release?> GetLatestApiRelease()

--- a/src/Sidekick.Apis.Poe/Clients/IPoeTradeClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/IPoeTradeClient.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Sidekick.Apis.Poe.Clients.Models;
 using Sidekick.Common.Game;
 using Sidekick.Common.Game.Languages;
@@ -7,7 +6,5 @@ namespace Sidekick.Apis.Poe.Clients;
 
 public interface IPoeTradeClient
 {
-    JsonSerializerOptions Options { get; }
-
     Task<FetchResult<TReturn>> Fetch<TReturn>(GameType game, IGameLanguage language, string path);
 }

--- a/src/Sidekick.Apis.Poe/Clients/PoeApiClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeApiClient.cs
@@ -7,32 +7,19 @@ using Sidekick.Common.Settings;
 
 namespace Sidekick.Apis.Poe.Clients;
 
-public class PoeApiClient : IPoeApiClient
+public class PoeApiClient(
+    ILogger<PoeTradeClient> logger,
+    IHttpClientFactory httpClientFactory,
+    ISettingsService settingsService) : IPoeApiClient
 {
     private const string PoeApiUrl = "https://api.pathofexile.com/";
 
-    private readonly ILogger logger;
-    private readonly ISettingsService settingsService;
-    private readonly IHttpClientFactory httpClientFactory;
-
-    public PoeApiClient(
-        ILogger<PoeTradeClient> logger,
-        IHttpClientFactory httpClientFactory,
-        ISettingsService settingsService)
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
-        this.logger = logger;
-        this.settingsService = settingsService;
-        this.httpClientFactory = httpClientFactory;
-
-        Options = new JsonSerializerOptions()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-        Options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
-    }
-
-    private JsonSerializerOptions Options { get; }
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
 
     private HttpClient CreateClient()
     {
@@ -59,7 +46,7 @@ public class PoeApiClient : IPoeApiClient
             }
 
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<TReturn>(content, Options);
+            var result = await JsonSerializer.DeserializeAsync<TReturn>(content, JsonSerializerOptions);
             if (result != null)
             {
                 return result;

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeClient.cs
@@ -12,7 +12,7 @@ public class PoeTradeClient(
     ILogger<PoeTradeClient> logger,
     IHttpClientFactory httpClientFactory) : IPoeTradeClient
 {
-    public JsonSerializerOptions Options { get; } = new()
+    public static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -46,7 +46,7 @@ public class PoeTradeClient(
 
             var content = await response.Content.ReadAsStreamAsync();
 
-            var result = await JsonSerializer.DeserializeAsync<FetchResult<TReturn>>(content, Options);
+            var result = await JsonSerializer.DeserializeAsync<FetchResult<TReturn>>(content, JsonSerializerOptions);
             if (result == null)
             {
                 throw new Exception($"[Trade Client] Could not understand the API response.");

--- a/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
+++ b/src/Sidekick.Apis.Poe/Clients/PoeTradeHandler.cs
@@ -18,6 +18,12 @@ public class PoeTradeHandler
     IGameLanguageProvider gameLanguageProvider
 ) : DelegatingHandler
 {
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         request.Headers.TryAddWithoutValidation("X-Powered-By", "Sidekick");
@@ -140,13 +146,8 @@ public class PoeTradeHandler
     {
         try
         {
-            var options = new JsonSerializerOptions()
-            {
-                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            };
             var content = await response.Content.ReadAsStreamAsync();
-            return await JsonSerializer.DeserializeAsync<ApiErrorResponse>(content, options);
+            return await JsonSerializer.DeserializeAsync<ApiErrorResponse>(content, JsonSerializerOptions);
         }
         catch (Exception)
         {

--- a/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
+++ b/src/Sidekick.Apis.PoeNinja/PoeNinjaClient.cs
@@ -14,35 +14,21 @@ namespace Sidekick.Apis.PoeNinja;
 /// <summary>
 /// https://poe.ninja/swagger
 /// </summary>
-public class PoeNinjaClient : IPoeNinjaClient
+public class PoeNinjaClient(
+    ICacheProvider cacheProvider,
+    ISettingsService settingsService,
+    IHttpClientFactory httpClientFactory,
+    ILogger<PoeNinjaClient> logger) : IPoeNinjaClient
 {
     private static readonly Uri baseUrl = new("https://poe.ninja/");
     private static readonly Uri apiBaseUrl = new("https://poe.ninja/api/data/");
 
-    private readonly ICacheProvider cacheProvider;
-    private readonly ISettingsService settingsService;
-    private readonly IHttpClientFactory httpClientFactory;
-    private readonly ILogger<PoeNinjaClient> logger;
-    private readonly JsonSerializerOptions options;
-
-    public PoeNinjaClient(
-        ICacheProvider cacheProvider,
-        ISettingsService settingsService,
-        IHttpClientFactory httpClientFactory,
-        ILogger<PoeNinjaClient> logger)
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
-        this.cacheProvider = cacheProvider;
-        this.settingsService = settingsService;
-        this.httpClientFactory = httpClientFactory;
-        this.logger = logger;
-
-        options = new JsonSerializerOptions()
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        };
-        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
-    }
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
+    };
 
     private HttpClient GetHttpClient()
     {
@@ -237,7 +223,7 @@ public class PoeNinjaClient : IPoeNinjaClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(url);
             var responseStream = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<PoeNinjaQueryResult<PoeNinjaItem>>(responseStream, options);
+            var result = await JsonSerializer.DeserializeAsync<PoeNinjaQueryResult<PoeNinjaItem>>(responseStream, JsonSerializerOptions);
             if (result == null)
             {
                 return [];
@@ -280,7 +266,7 @@ public class PoeNinjaClient : IPoeNinjaClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(url);
             var responseStream = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<PoeNinjaQueryResult<PoeNinjaCurrency>>(responseStream, options);
+            var result = await JsonSerializer.DeserializeAsync<PoeNinjaQueryResult<PoeNinjaCurrency>>(responseStream, JsonSerializerOptions);
             if (result == null)
             {
                 return [];

--- a/src/Sidekick.Apis.PoePriceInfo/PoePriceInfoClient.cs
+++ b/src/Sidekick.Apis.PoePriceInfo/PoePriceInfoClient.cs
@@ -14,7 +14,7 @@ public class PoePriceInfoClient(
     ILogger<PoePriceInfoClient> logger,
     IHttpClientFactory httpClientFactory) : IPoePriceInfoClient
 {
-    private readonly JsonSerializerOptions options = new()
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase
     };
@@ -43,7 +43,7 @@ public class PoePriceInfoClient(
             using var client = GetHttpClient();
             var response = await client.GetAsync("?l=" + leagueId.GetUrlSlugForLeague() + "&i=" + encodedItem);
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<PriceInfoResult>(content, options);
+            var result = await JsonSerializer.DeserializeAsync<PriceInfoResult>(content, JsonSerializerOptions);
 
             if (result == null)
             {

--- a/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
+++ b/src/Sidekick.Apis.PoeWiki/PoeWikiClient.cs
@@ -22,12 +22,11 @@ public class PoeWikiClient
     ICacheProvider cacheProvider
 ) : IPoeWikiClient
 {
-    private readonly JsonSerializerOptions options = new()
+    private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         PropertyNameCaseInsensitive = true
     };
-
     private const string PoeWikiBaseUri = "https://www.poewiki.net/";
     private const string PoeWikiSubUrl = "w/index.php?search=";
 
@@ -137,7 +136,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<MapResult>>(content, options);
+            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<MapResult>>(content, JsonSerializerOptions);
             return result?.CargoQuery.Select(x => x.Title).FirstOrDefault();
         }
         catch (Exception e)
@@ -165,7 +164,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<BossResult>>(content, options);
+            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<BossResult>>(content, JsonSerializerOptions);
             if (result == null)
             {
                 return null;
@@ -210,7 +209,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<CargoQueryResult<ItemResult>>(content, options);
+            var result = JsonSerializer.Deserialize<CargoQueryResult<ItemResult>>(content, JsonSerializerOptions);
             if (result == null)
             {
                 return null;
@@ -257,7 +256,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemIdResult>>(content, options);
+            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemIdResult>>(content, JsonSerializerOptions);
             if (result == null)
             {
                 return null;
@@ -301,7 +300,7 @@ public class PoeWikiClient
             using var client = GetHttpClient();
             var response = await client.GetAsync(QueryStringHelper.ToQueryString(query));
             var content = await response.Content.ReadAsStreamAsync();
-            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemNameMetadataIdResult>>(content, options);
+            var result = await JsonSerializer.DeserializeAsync<CargoQueryResult<ItemNameMetadataIdResult>>(content, JsonSerializerOptions);
             if (result == null)
             {
                 return null;

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/ParserFixture.cs
@@ -1,7 +1,6 @@
 using Bunit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Filters;
 using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.Poe.Parser.Properties;
@@ -29,7 +28,6 @@ public class ParserFixture : IAsyncLifetime
     public ITradeFilterService TradeFilterService { get; private set; } = null!;
     public ISettingsService SettingsService { get; private set; } = null!;
     public IModifierProvider ModifierProvider { get; private set; } = null!;
-    public IPoeTradeClient PoeTradeClient { get; private set; } = null!;
     private TestContext TestContext { get; set; } = null!;
 
     public async Task InitializeAsync()
@@ -67,7 +65,6 @@ public class ParserFixture : IAsyncLifetime
         FilterProvider = TestContext.Services.GetRequiredService<IFilterProvider>();
         TradeFilterService = TestContext.Services.GetRequiredService<ITradeFilterService>();
         ModifierProvider = TestContext.Services.GetRequiredService<IModifierProvider>();
-        PoeTradeClient = TestContext.Services.GetRequiredService<IPoeTradeClient>();
     }
 
     public Task DisposeAsync()

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/Query/TradeSearchServiceTests.cs
@@ -14,7 +14,7 @@ public class TradeSearchServiceTests
     private readonly ITradeFilterService tradeFilterService;
     private readonly MockHttpClient mockHttpClient = new();
     private readonly TradeSearchService tradeSearchService;
-    private readonly JsonSerializerOptions jsonSerializerOptions = new()
+    private static readonly JsonSerializerOptions jsonSerializerOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
@@ -35,7 +35,6 @@ public class TradeSearchServiceTests
             NullLogger<TradeSearchService>.Instance,
             fixture.GameLanguageProvider,
             fixture.SettingsService,
-            fixture.PoeTradeClient,
             fixture.ModifierProvider,
             fixture.FilterProvider,
             fixture.PropertyParser,


### PR DESCRIPTION
So here's a suggestion to address this topic: https://learn.microsoft.com/en-us/dotnet/standard/serialization/system-text-json/configure-options#reuse-jsonserializeroptions-instances

Which was the primary thing I wanted to address with the previous PR (but I got carried away ...)

Basically improving performance for serialization/deserialization.