### PR TITLE
Rename properties and methods on SearchFilters for simplicity

### DIFF
--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AreaLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AreaLevelProperty.cs
@@ -39,6 +39,6 @@ public class AreaLevelProperty(IGameLanguageProvider gameLanguageProvider) : Pro
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.AreaLevel = intFilter.Checked ? new StatFilterValue(intFilter) : null;
+        searchFilters.MapFilters.Filters.AreaLevel = intFilter.Checked ? new StatFilterValue(intFilter) : null;
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ArmourProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ArmourProperty.cs
@@ -47,8 +47,8 @@ public class ArmourProperty
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateArmourFilters().Filters.Armour = new StatFilterValue(intFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.Armour = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.ArmourFilters.Filters.Armour = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.Armour = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AttacksPerSecondProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/AttacksPerSecondProperty.cs
@@ -42,8 +42,8 @@ public class AttacksPerSecondProperty(IGameLanguageProvider gameLanguageProvider
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.AttacksPerSecond = new StatFilterValue(doubleFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.AttacksPerSecond = new StatFilterValue(doubleFilter); break;
+            case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.AttacksPerSecond = new StatFilterValue(doubleFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.AttacksPerSecond = new StatFilterValue(doubleFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightRavagedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightRavagedProperty.cs
@@ -34,6 +34,6 @@ public class BlightRavagedProperty(IGameLanguageProvider gameLanguageProvider) :
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.BlightRavavaged = new SearchFilterOption(filter);
+        searchFilters.MapFilters.Filters.BlightRavavaged = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlightedProperty.cs
@@ -34,6 +34,6 @@ public class BlightedProperty(IGameLanguageProvider gameLanguageProvider) : Prop
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.Blighted = new SearchFilterOption(filter);
+        searchFilters.MapFilters.Filters.Blighted = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlockChanceProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/BlockChanceProperty.cs
@@ -46,8 +46,8 @@ public class BlockChanceProperty(IGameLanguageProvider gameLanguageProvider, Gam
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateArmourFilters().Filters.BlockChance = new StatFilterValue(intFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.BlockChance = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.ArmourFilters.Filters.BlockChance = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.BlockChance = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CorruptedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CorruptedProperty.cs
@@ -34,6 +34,6 @@ public class CorruptedProperty(IGameLanguageProvider gameLanguageProvider) : Pro
             return;
         }
 
-        searchFilters.GetOrCreateMiscFilters().Filters.Corrupted = new SearchFilterOption(triStateFilter);
+        searchFilters.MiscFilters.Filters.Corrupted = new SearchFilterOption(triStateFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CriticalHitChanceProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CriticalHitChanceProperty.cs
@@ -46,8 +46,8 @@ public class CriticalHitChanceProperty(IGameLanguageProvider gameLanguageProvide
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.CriticalHitChance = new StatFilterValue(doubleFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.CriticalHitChance = new StatFilterValue(doubleFilter); break;
+            case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.CriticalHitChance = new StatFilterValue(doubleFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.CriticalHitChance = new StatFilterValue(doubleFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CrusaderProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/CrusaderProperty.cs
@@ -33,6 +33,6 @@ public class CrusaderProperty(IGameLanguageProvider gameLanguageProvider) : Prop
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.CrusaderItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.CrusaderItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ElderProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ElderProperty.cs
@@ -33,6 +33,6 @@ public class ElderProperty(IGameLanguageProvider gameLanguageProvider) : Propert
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.ElderItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.ElderItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EnergyShieldProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EnergyShieldProperty.cs
@@ -59,8 +59,8 @@ public class EnergyShieldProperty
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateArmourFilters().Filters.EnergyShield = new StatFilterValue(intFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.EnergyShield = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.ArmourFilters.Filters.EnergyShield = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.EnergyShield = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EvasionRatingProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/EvasionRatingProperty.cs
@@ -43,8 +43,8 @@ public class EvasionRatingProperty(IGameLanguageProvider gameLanguageProvider, G
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateArmourFilters().Filters.EvasionRating = new StatFilterValue(intFilter); break;
-            case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.EvasionRating = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.ArmourFilters.Filters.EvasionRating = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.EvasionRating = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/GemLevelProperty.cs
@@ -48,11 +48,11 @@ public class GemLevelProperty
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateMiscFilters().Filters.GemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.MiscFilters.Filters.GemLevel = new StatFilterValue(intFilter); break;
 
-            case GameType.PathOfExile2 when apiInvariantItemProvider.UncutGemIds.Contains(item.Header.ApiItemId ?? string.Empty): searchFilters.GetOrCreateTypeFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2 when apiInvariantItemProvider.UncutGemIds.Contains(item.Header.ApiItemId ?? string.Empty): searchFilters.TypeFilters.Filters.ItemLevel = new StatFilterValue(intFilter); break;
 
-            case GameType.PathOfExile2: searchFilters.GetOrCreateMiscFilters().Filters.GemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.MiscFilters.Filters.GemLevel = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/HunterProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/HunterProperty.cs
@@ -33,6 +33,6 @@ public class HunterProperty(IGameLanguageProvider gameLanguageProvider) : Proper
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.HunterItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.HunterItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemLevelProperty.cs
@@ -40,9 +40,9 @@ public class ItemLevelProperty(IGameLanguageProvider gameLanguageProvider, GameT
 
         switch (game)
         {
-            case GameType.PathOfExile: searchFilters.GetOrCreateMiscFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile: searchFilters.MiscFilters.Filters.ItemLevel = new StatFilterValue(intFilter); break;
 
-            case GameType.PathOfExile2: searchFilters.GetOrCreateTypeFilters().Filters.ItemLevel = new StatFilterValue(intFilter); break;
+            case GameType.PathOfExile2: searchFilters.TypeFilters.Filters.ItemLevel = new StatFilterValue(intFilter); break;
         }
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemQuantityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemQuantityProperty.cs
@@ -41,6 +41,6 @@ public class ItemQuantityProperty(IGameLanguageProvider gameLanguageProvider) : 
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.ItemQuantity = new StatFilterValue(intFilter);
+        searchFilters.MapFilters.Filters.ItemQuantity = new StatFilterValue(intFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemRarityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ItemRarityProperty.cs
@@ -41,6 +41,6 @@ public class ItemRarityProperty(IGameLanguageProvider gameLanguageProvider) : Pr
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.ItemRarity = new StatFilterValue(intFilter);
+        searchFilters.MapFilters.Filters.ItemRarity = new StatFilterValue(intFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MapTierProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MapTierProperty.cs
@@ -39,6 +39,6 @@ public class MapTierProperty(IGameLanguageProvider gameLanguageProvider) : Prope
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.MapTier = new StatFilterValue(intFilter);
+        searchFilters.MapFilters.Filters.MapTier = new StatFilterValue(intFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MonsterPackSizeProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/MonsterPackSizeProperty.cs
@@ -41,6 +41,6 @@ public class MonsterPackSizeProperty(IGameLanguageProvider gameLanguageProvider)
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMapFilters().Filters.MonsterPackSize = new StatFilterValue(intFilter);
+        searchFilters.MapFilters.Filters.MonsterPackSize = new StatFilterValue(intFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/QualityProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/QualityProperty.cs
@@ -41,6 +41,6 @@ public class QualityProperty(IGameLanguageProvider gameLanguageProvider) : Prope
     {
         if (!filter.Checked || filter is not IntPropertyFilter intFilter) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.Quality = new StatFilterValue(intFilter);
+        searchFilters.MiscFilters.Filters.Quality = new StatFilterValue(intFilter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/RedeemerProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/RedeemerProperty.cs
@@ -33,6 +33,6 @@ public class RedeemerProperty(IGameLanguageProvider gameLanguageProvider) : Prop
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.RedeemerItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.RedeemerItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ShaperProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/ShaperProperty.cs
@@ -33,6 +33,6 @@ public class ShaperProperty(IGameLanguageProvider gameLanguageProvider) : Proper
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.ShaperItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.ShaperItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/UnidentifiedProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/UnidentifiedProperty.cs
@@ -38,6 +38,6 @@ public class UnidentifiedProperty(IGameLanguageProvider gameLanguageProvider) : 
             return;
         }
 
-        searchFilters.GetOrCreateMiscFilters().Filters.Identified = new SearchFilterOption(triStatePropertyFilter.Checked is true ? "false" : "true");
+        searchFilters.MiscFilters.Filters.Identified = new SearchFilterOption(triStatePropertyFilter.Checked is true ? "false" : "true");
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WarlordProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WarlordProperty.cs
@@ -33,6 +33,6 @@ public class WarlordProperty(IGameLanguageProvider gameLanguageProvider) : Prope
     {
         if (!filter.Checked) return;
 
-        searchFilters.GetOrCreateMiscFilters().Filters.WarlordItem = new SearchFilterOption(filter);
+        searchFilters.MiscFilters.Filters.WarlordItem = new SearchFilterOption(filter);
     }
 }

--- a/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Properties/Definitions/WeaponDamageProperty.cs
@@ -202,8 +202,8 @@ public class WeaponDamageProperty
         {
             switch (game)
             {
-                case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.Damage = new StatFilterValue(damageFilter); break;
-                case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.Damage = new StatFilterValue(damageFilter); break;
+                case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.Damage = new StatFilterValue(damageFilter); break;
+                case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.Damage = new StatFilterValue(damageFilter); break;
             }
         }
 
@@ -211,8 +211,8 @@ public class WeaponDamageProperty
         {
             switch (game)
             {
-                case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.PhysicalDps = new StatFilterValue(physicalDpsFilter); break;
-                case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.PhysicalDps = new StatFilterValue(physicalDpsFilter); break;
+                case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.PhysicalDps = new StatFilterValue(physicalDpsFilter); break;
+                case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.PhysicalDps = new StatFilterValue(physicalDpsFilter); break;
             }
         }
 
@@ -220,22 +220,22 @@ public class WeaponDamageProperty
         {
             switch (game)
             {
-                case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.ElementalDps = new StatFilterValue(elementalDpsFilter); break;
-                case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.ElementalDps = new StatFilterValue(elementalDpsFilter); break;
+                case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.ElementalDps = new StatFilterValue(elementalDpsFilter); break;
+                case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.ElementalDps = new StatFilterValue(elementalDpsFilter); break;
             }
         }
 
         if (filter.Text == localizer["ChaosDps"] && filter is DoublePropertyFilter chaosDpsFilter)
         {
-            // searchFilters.GetOrCreateWeaponFilters().Filters.ChaosDps = new StatFilterValue(chaosDpsFilter);
+            // searchFilters.GetOrCreateWeaponFilters.Filters.ChaosDps = new StatFilterValue(chaosDpsFilter);
         }
 
         if (filter.Text == localizer["Dps"] && filter is DoublePropertyFilter dpsFilter)
         {
             switch (game)
             {
-                case GameType.PathOfExile: searchFilters.GetOrCreateWeaponFilters().Filters.DamagePerSecond = new StatFilterValue(dpsFilter); break;
-                case GameType.PathOfExile2: searchFilters.GetOrCreateEquipmentFilters().Filters.DamagePerSecond = new StatFilterValue(dpsFilter); break;
+                case GameType.PathOfExile: searchFilters.WeaponFilters.Filters.DamagePerSecond = new StatFilterValue(dpsFilter); break;
+                case GameType.PathOfExile2: searchFilters.EquipmentFilters.Filters.DamagePerSecond = new StatFilterValue(dpsFilter); break;
             }
         }
     }

--- a/src/Sidekick.Apis.Poe/Trade/Requests/Filters/SearchFilters.cs
+++ b/src/Sidekick.Apis.Poe/Trade/Requests/Filters/SearchFilters.cs
@@ -5,34 +5,40 @@ namespace Sidekick.Apis.Poe.Trade.Requests.Filters;
 public class SearchFilters
 {
     [JsonPropertyName("type_filters")]
-    public TypeFilterGroup? TypeFilters { get; set; }
+    public TypeFilterGroup? Type_filters { get; set; }
 
-    public TypeFilterGroup GetOrCreateTypeFilters() => TypeFilters ??= new();
+    [JsonIgnore]
+    public TypeFilterGroup TypeFilters => Type_filters ??= new();
 
     [JsonPropertyName("trade_filters")]
-    public TradeFilterGroup? TradeFilters { get; set; }
+    public TradeFilterGroup? Trade_filters { get; set; }
 
-    public TradeFilterGroup GetOrCreateTradeFilters() => TradeFilters ??= new();
+    [JsonIgnore]
+    public TradeFilterGroup TradeFilters => Trade_filters ??= new();
 
     [JsonPropertyName("misc_filters")]
-    public MiscFilterGroup? MiscFilters { get; set; }
+    public MiscFilterGroup? Misc_filters { get; set; }
 
-    public MiscFilterGroup GetOrCreateMiscFilters() => MiscFilters ??= new();
+    [JsonIgnore]
+    public MiscFilterGroup MiscFilters => Misc_filters ??= new();
 
     [JsonPropertyName("weapon_filters")]
-    public WeaponFilterGroup? WeaponFilters { get; set; }
+    public WeaponFilterGroup? Weapon_filters { get; set; }
 
-    public WeaponFilterGroup GetOrCreateWeaponFilters() => WeaponFilters ??= new();
+    [JsonIgnore]
+    public WeaponFilterGroup WeaponFilters => Weapon_filters ??= new();
 
     [JsonPropertyName("armour_filters")]
-    public ArmourFilterGroup? ArmourFilters { get; set; }
+    public ArmourFilterGroup? Armour_filters { get; set; }
 
-    public ArmourFilterGroup GetOrCreateArmourFilters() => ArmourFilters ??= new();
+    [JsonIgnore]
+    public ArmourFilterGroup ArmourFilters => Armour_filters ??= new();
 
     [JsonPropertyName("equipment_filters")]
-    public EquipmentFilterGroup? EquipmentFilters { get; set; }
+    public EquipmentFilterGroup? Equipment_filters { get; set; }
 
-    public EquipmentFilterGroup GetOrCreateEquipmentFilters() => EquipmentFilters ??= new();
+    [JsonIgnore]
+    public EquipmentFilterGroup EquipmentFilters => Equipment_filters ??= new();
 
     [JsonPropertyName("socket_filters")]
     public SocketFilterGroup? SocketFilters { get; set; }
@@ -41,8 +47,9 @@ public class SearchFilters
     public RequirementFilterGroup? RequirementFilters { get; set; }
 
     [JsonPropertyName("map_filters")]
-    public MapFilterGroup? MapFilters { get; set; }
+    public MapFilterGroup? Map_filters { get; set; }
 
-    public MapFilterGroup GetOrCreateMapFilters() => MapFilters ??= new();
+    [JsonIgnore]
+    public MapFilterGroup MapFilters => Map_filters ??= new();
 
 }

--- a/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe/Trade/TradeSearchService.cs
@@ -71,7 +71,7 @@ public class TradeSearchService
             }
             else if (propertyFilters.ClassFilterApplied)
             {
-                query.Filters.GetOrCreateTypeFilters().Filters.Category = GetCategoryFilter(item.Header.ItemCategory);
+                query.Filters.TypeFilters.Filters.Category = GetCategoryFilter(item.Header.ItemCategory);
             }
 
             if (item.Header.Category == Category.ItemisedMonster && !string.IsNullOrEmpty(itemApiNameToUse))
@@ -82,7 +82,7 @@ public class TradeSearchService
             else if (item.Header.Rarity == Rarity.Unique && !string.IsNullOrEmpty(itemApiNameToUse))
             {
                 query.Name = itemApiNameToUse;
-                query.Filters.GetOrCreateTypeFilters().Filters.Rarity = new SearchFilterOption("Unique");
+                query.Filters.TypeFilters.Filters.Rarity = new SearchFilterOption("Unique");
             }
             else if (propertyFilters?.RarityFilterApplied ?? false)
             {
@@ -95,7 +95,7 @@ public class TradeSearchService
                     _ => "nonunique",
                 };
 
-                query.Filters.GetOrCreateTypeFilters().Filters.Rarity = new SearchFilterOption(rarity);
+                query.Filters.TypeFilters.Filters.Rarity = new SearchFilterOption(rarity);
             }
 
             var currency = item.Header.Game == GameType.PathOfExile ? await settingsService.GetString(SettingKeys.PriceCheckCurrency) : await settingsService.GetString(SettingKeys.PriceCheckCurrencyPoE2);
@@ -104,7 +104,7 @@ public class TradeSearchService
             currency = filterProvider.GetPriceOption(currency);
             if (!string.IsNullOrEmpty(currency) || currencyMin > 0 || currencyMax > 0)
             {
-                query.Filters.GetOrCreateTradeFilters().Filters.Price = new(currency)
+                query.Filters.TradeFilters.Filters.Price = new(currency)
                 {
                     Min = currencyMin > 0 ? currencyMin : null,
                     Max = currencyMax > 0 ? currencyMax : null,
@@ -114,7 +114,7 @@ public class TradeSearchService
             var timeFrame = await settingsService.GetString(SettingKeys.PriceCheckItemListedAge);
             if (!string.IsNullOrWhiteSpace(timeFrame))
             {
-                query.Filters.GetOrCreateTradeFilters().Filters.Indexed = new(timeFrame);
+                query.Filters.TradeFilters.Filters.Indexed = new(timeFrame);
             }
 
             SetSocketFilters(item, query.Filters);


### PR DESCRIPTION
The actual changes are in `src/Sidekick.Apis.Poe/Trade/Requests/Filters/SearchFilters.cs`.

I figured I saw this in some other project I browsed and thought it might be a nice fit there. I think the expressions looks a lot cleaner atleast?