### PR TITLE
Reduce Services to be Initialized

### DIFF
--- a/src/Sidekick.Common/Game/Languages/GameLanguageProvider.cs
+++ b/src/Sidekick.Common/Game/Languages/GameLanguageProvider.cs
@@ -20,9 +20,16 @@ public class GameLanguageProvider(ISettingsService settingsService) : IGameLangu
     /// <inheritdoc />
     public async Task Initialize()
     {
-        var languageCode = await settingsService.GetString(SettingKeys.LanguageParser);
-        language = GetLanguage(languageCode ?? EnglishLanguageCode);
+        var languageCode = await settingsService.GetString(SettingKeys.LanguageParser) ?? EnglishLanguageCode;
+        language = GetLanguage(languageCode);
         invariantLanguage = GetInvariantLanguage();
+
+        // If the language is Chinese, we are forcing the use invariant trade results flag.
+        var useInvariantTradeResults = await settingsService.GetBool(SettingKeys.UseInvariantTradeResults);
+        if (languageCode == "zh" && !useInvariantTradeResults)
+        {
+            await settingsService.Set(SettingKeys.UseInvariantTradeResults, true);
+        }
     }
 
     public List<GameLanguageAttribute> GetList()

--- a/src/Sidekick.Common/ServiceCollectionExtensions.cs
+++ b/src/Sidekick.Common/ServiceCollectionExtensions.cs
@@ -30,8 +30,8 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IBrowserProvider, BrowserProvider>();
         services.AddSingleton<ICacheProvider, CacheProvider>();
         services.AddSingleton<IFolderProvider, FolderProvider>();
+        services.AddSingleton<ISettingsService, SettingsService>();
 
-        services.AddSidekickInitializableService<ISettingsService, SettingsService>();
         services.AddSidekickInitializableService<IGameLanguageProvider, GameLanguageProvider>();
         services.AddSidekickInitializableService<IUiLanguageProvider, UiLanguageProvider>();
 

--- a/src/Sidekick.Common/Settings/ISettingsService.cs
+++ b/src/Sidekick.Common/Settings/ISettingsService.cs
@@ -1,8 +1,6 @@
-using Sidekick.Common.Initialization;
-
 namespace Sidekick.Common.Settings;
 
-public interface ISettingsService : IInitializableService
+public interface ISettingsService
 {
     /// <summary>
     /// Event when any setting is changed.

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -14,19 +14,6 @@ public class SettingsService(
 {
     public event Action? OnSettingsChanged;
 
-    public int Priority { get; set; } = int.MinValue;
-
-    public async Task Initialize()
-    {
-        // If the language is Chinese, we are forcing the use invariant trade results flag.
-        var useInvariantTradeResults = await GetBool(SettingKeys.UseInvariantTradeResults);
-        var languageParser = await GetString(SettingKeys.LanguageParser);
-        if (languageParser == "zh" && !useInvariantTradeResults)
-        {
-            await Set(SettingKeys.UseInvariantTradeResults, true);
-        }
-    }
-
     public async Task<bool> GetBool(string key)
     {
         await using var dbContext = new SidekickDbContext(dbContextOptions);


### PR DESCRIPTION
I figured it was nice if maybe the SettingsService didn't need to be initialized - as a lot of other services depend on it. So I moved it's intialization to GameLanguageProvider - where I figured it also made sense.

And I removed the Initialization from UiLanguageProvider as I assume that behaviour should be handled by the DefaultSettings?