### PR TITLE
Allow the application to continue working after a failed automatic update

### DIFF
--- a/src/Sidekick.Common.Ui/Alerts/AlertError.razor
+++ b/src/Sidekick.Common.Ui/Alerts/AlertError.razor
@@ -1,4 +1,4 @@
-﻿<div class="flex flex-nowrap items-center w-full bg-red-600 p-3 text-white">
+﻿<div class="flex flex-nowrap items-center w-full @BackgroundClass p-3">
     <svg class="w-6 h-6 min-w-6 min-h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/>
     </svg>
@@ -11,5 +11,10 @@
 
     [Parameter]
     public required RenderFragment ChildContent { get; set; }
+
+    [Parameter]
+    public bool IsCritical { get; set; } = true;
+
+    private string BackgroundClass => IsCritical ? "bg-red-700 text-white" : "bg-orange-700 text-white";
 
 }

--- a/src/Sidekick.Common.Ui/Alerts/AlertException.razor
+++ b/src/Sidekick.Common.Ui/Alerts/AlertException.razor
@@ -1,0 +1,28 @@
+﻿@using Sidekick.Common.Exceptions
+
+<AlertError IsCritical="Exception.IsCritical">
+    <TextBase>@Exception.Message</TextBase>
+
+    @foreach (var additionalInformation in Exception.AdditionalInformation)
+    {
+        <div>
+            <TextCaption Class="mt-1">@additionalInformation</TextCaption>
+        </div>
+    }
+
+    <div class="hidden mt-1">
+        <div>
+            @Exception.Message
+        </div>
+        <div>
+            @((MarkupString)(Exception.StackTrace?.Replace("\n", "<br/>") ?? ""))
+        </div>
+    </div>
+</AlertError>
+
+@code {
+
+    [Parameter]
+    public required SidekickException Exception { get; set; }
+
+}

--- a/src/Sidekick.Common.Ui/Errors/SidekickErrorBoundary.razor
+++ b/src/Sidekick.Common.Ui/Errors/SidekickErrorBoundary.razor
@@ -9,20 +9,20 @@
         {
             @ErrorContent(this)
         }
+        else if (SidekickException != null)
+        {
+            <AlertException Exception="SidekickException"/>
+        }
         else
         {
-            <AlertError>
+            <AlertError IsCritical="@IsCritical">
                 <TextBase>@Message</TextBase>
 
-                @if (AdditionalInformation.Any())
+                @foreach (var additionalInformation in AdditionalInformation)
                 {
-                    <Heading3 Class="mt-2">Additional Information</Heading3>
-                    @foreach (var additionalInformation in AdditionalInformation)
-                    {
-                        <div>
-                            <TextCaption Class="mt-1">@additionalInformation</TextCaption>
-                        </div>
-                    }
+                    <div>
+                        <TextCaption Class="mt-1">@additionalInformation</TextCaption>
+                    </div>
                 }
 
                 <div class="hidden mt-1">
@@ -61,6 +61,8 @@
 
     public Exception? Exception => Boundary?.CurrentException;
 
+    public SidekickException? SidekickException => Exception as SidekickException;
+
     protected override void OnAfterRender(bool firstRender)
     {
         if (Boundary?.CurrentException != null)
@@ -71,43 +73,10 @@
         base.OnAfterRender(firstRender);
     }
 
-    public string Message
-    {
-        get
-        {
-            if (Boundary?.CurrentException is SidekickException sidekickException)
-            {
-                return sidekickException.Message;
-            }
+    public string Message => SidekickException?.Message ?? "This application may no longer respond until reloaded. If this issue keeps reoccurring, please open a ticket on our github page.";
 
-            return "This application may no longer respond until reloaded. If this issue keeps reoccurring, please open a ticket on our github page.";
-        }
-    }
+    public List<string> AdditionalInformation => SidekickException?.AdditionalInformation ?? [];
 
-    public List<string> AdditionalInformation
-    {
-        get
-        {
-            if (Boundary?.CurrentException is SidekickException sidekickException)
-            {
-                return sidekickException.AdditionalInformation;
-            }
-
-            return [];
-        }
-    }
-
-    public bool IsCritical
-    {
-        get
-        {
-            if (Boundary?.CurrentException is SidekickException sidekickException)
-            {
-                return sidekickException.IsCritical;
-            }
-
-            return true;
-        }
-    }
+    public bool IsCritical => SidekickException?.IsCritical ?? true;
 
 }

--- a/src/Sidekick.Common.Updater/Components/Update.fr.resx
+++ b/src/Sidekick.Common.Updater/Components/Update.fr.resx
@@ -127,9 +127,6 @@
     <value>Vérification de mise à jour</value>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-  <data name="Update_Cant_Download" type="System.Resources.ResXNullRef, System.Windows.Forms">
-    <value />
-  </data>
   <data name="Continue" xml:space="preserve">
       <value>Continuer</value>
   </data>

--- a/src/Sidekick.Common.Updater/Components/Update.razor
+++ b/src/Sidekick.Common.Updater/Components/Update.razor
@@ -13,9 +13,9 @@
     </TopContent>
 
     <ChildContent>
-        @if (Error)
+        @if (Exception != null)
         {
-            <AlertError>@Resources["Update_Cant_Download"]</AlertError>
+            <AlertException Exception="Exception"/>
         }
         else if (UpdateInfo == null)
         {
@@ -84,11 +84,11 @@
 
 @code {
 
-    private bool Error { get; set; }
-
     private bool Updating { get; set; }
 
     private UpdateInfo? UpdateInfo { get; set; }
+
+    private SidekickException? Exception { get; set; }
 
     private RenderFragment GetNotes(VelopackAsset asset) => @<FormFieldset Legend="@($"Version {asset.Version}")">
                                                                 <div
@@ -107,36 +107,43 @@
         });
         await base.OnInitializedAsync();
 
-        if (Debugger.IsAttached)
+        try
         {
-            // Comment the following line to get the update view to stick when debugging.
-            Continue();
-            return;
-        }
-
-        if (AutoUpdater.IsUpdaterInstalled())
-        {
-            UpdateInfo = await AutoUpdater.CheckForUpdates();
-
-            if (UpdateInfo is null)
+            if (Debugger.IsAttached)
             {
-                // There's no available updates
-                NavigationManager.NavigateTo("/setup");
+                // Comment the following line to get the update view to stick when debugging.
+                Continue();
+                return;
+            }
+
+            if (AutoUpdater.IsUpdaterInstalled())
+            {
+                UpdateInfo = await AutoUpdater.CheckForUpdates();
+
+                if (UpdateInfo is null)
+                {
+                    // There's no available updates
+                    NavigationManager.NavigateTo("/setup");
+                }
+                else
+                {
+                    CurrentView.Initialize(new ViewOptions()
+                    {
+                        Title = Resources["Update"],
+                        Width = 400,
+                        Height = 500,
+                    });
+                }
             }
             else
             {
-                CurrentView.Initialize(new ViewOptions()
-                {
-                    Title = Resources["Update"],
-                    Width = 400,
-                    Height = 500,
-                });
+                Logger.LogWarning("[AutoUpdater] UpdateManager is not installed.");
+                NavigationManager.NavigateTo("/setup");
             }
         }
-        else
+        catch (SidekickException e)
         {
-            Logger.LogWarning("[AutoUpdater] UpdateManager is not installed.");
-            NavigationManager.NavigateTo("/setup");
+            Exception = e;
         }
     }
 
@@ -156,18 +163,18 @@
     {
         if (UpdateInfo == null) throw new SidekickException("Could not apply the update successfully.");
 
-        Updating = true;
-        StateHasChanged();
-
         try
         {
+            Updating = true;
+            StateHasChanged();
+
             await AutoUpdater.UpdateAndRestart(UpdateInfo);
-        }
-        catch (Exception e)
-        {
-            Logger.LogError(e, e.Message);
-            Error = true;
             Updating = false;
+            StateHasChanged();
+        }
+        catch (SidekickException e)
+        {
+            Exception = e;
             StateHasChanged();
         }
     }

--- a/src/Sidekick.Common.Updater/Components/Update.resx
+++ b/src/Sidekick.Common.Updater/Components/Update.resx
@@ -126,9 +126,6 @@
   <data name="Checking_For_Updates" xml:space="preserve">
     <value>Checking for updates...</value>
   </data>
-  <data name="Update_Cant_Download" xml:space="preserve">
-    <value>Could not download the update automatically. You can try to download the latest version from https://sidekick-poe.github.io/</value>
-  </data>
   <data name="Continue" xml:space="preserve">
       <value>Continue</value>
   </data>

--- a/src/Sidekick.Common/Exceptions/SidekickException.cs
+++ b/src/Sidekick.Common/Exceptions/SidekickException.cs
@@ -18,9 +18,9 @@ public class SidekickException : Exception
         AdditionalInformation = additionalInformation.ToList();
     }
 
-    public List<string> AdditionalInformation { get; set; } = [];
+    public List<string> AdditionalInformation { get; init; } = [];
 
-    public virtual bool IsCritical => true;
+    public virtual bool IsCritical { get; init; } = true;
 
     /// <summary>
     /// Gets or sets the actions that can be taken in response to the exception.


### PR DESCRIPTION
Replaced generic error handling with `SidekickException` integration, streamlining error display and improving UI feedback with `AlertException`. Enhanced robustness of the `AutoUpdater` by adding detailed error handling for update and installation processes.

Fixes #598 