### PR TITLE
Allow the application to start even if the API is down

### DIFF
--- a/src/Sidekick.Apis.Poe/Filters/FilterProvider.cs
+++ b/src/Sidekick.Apis.Poe/Filters/FilterProvider.cs
@@ -1,5 +1,6 @@
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Filters.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -26,6 +27,8 @@ public class FilterProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);
         var game = leagueId.GetGameFromLeagueId();
         var cacheKey = $"{game.GetValueAttribute()}_Filters";

--- a/src/Sidekick.Apis.Poe/Items/ApiInvariantItemProvider.cs
+++ b/src/Sidekick.Apis.Poe/Items/ApiInvariantItemProvider.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Items.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -30,6 +31,8 @@ public class ApiInvariantItemProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         IdDictionary.Clear();
 
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);

--- a/src/Sidekick.Apis.Poe/Items/ApiItemProvider.cs
+++ b/src/Sidekick.Apis.Poe/Items/ApiItemProvider.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Items.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -33,6 +34,8 @@ public class ApiItemProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         NameAndTypeDictionary.Clear();
         NameAndTypeRegex.Clear();
 

--- a/src/Sidekick.Apis.Poe/Leagues/LeagueProvider.cs
+++ b/src/Sidekick.Apis.Poe/Leagues/LeagueProvider.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Logging;
 using Sidekick.Apis.Poe.Clients;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Exceptions;

--- a/src/Sidekick.Apis.Poe/Modifiers/InvariantModifierProvider.cs
+++ b/src/Sidekick.Apis.Poe/Modifiers/InvariantModifierProvider.cs
@@ -1,6 +1,6 @@
-using System.Diagnostics;
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Modifiers.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -29,11 +29,11 @@ public class InvariantModifierProvider
 
     public List<string> LightningWeaponDamageIds { get; } = [];
 
-    public string ClusterJewelSmallPassiveCountModifierId { get; private set; } = null!;
+    public string ClusterJewelSmallPassiveCountModifierId { get; private set; } = string.Empty;
 
-    public string ClusterJewelSmallPassiveGrantModifierId { get; private set; } = null!;
+    public string ClusterJewelSmallPassiveGrantModifierId { get; private set; } = string.Empty;
 
-    public Dictionary<int, string> ClusterJewelSmallPassiveGrantOptions { get; private set; } = null!;
+    public Dictionary<int, string> ClusterJewelSmallPassiveGrantOptions { get; private set; } = [];
 
     /// <inheritdoc/>
     public int Priority => 100;
@@ -41,6 +41,8 @@ public class InvariantModifierProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         var result = await GetList();
         InitializeIgnore(result);
         InitializeIncursionRooms(result);

--- a/src/Sidekick.Apis.Poe/Modifiers/ModifierProvider.cs
+++ b/src/Sidekick.Apis.Poe/Modifiers/ModifierProvider.cs
@@ -2,6 +2,7 @@ using System.Text.RegularExpressions;
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Fuzzy;
 using Sidekick.Apis.Poe.Modifiers.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -55,6 +56,8 @@ public class ModifierProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);
         var game = leagueId.GetGameFromLeagueId();
         var cacheKey = $"{game.GetValueAttribute()}_Modifiers";

--- a/src/Sidekick.Apis.Poe/Parser/Pseudo/PseudoParser.cs
+++ b/src/Sidekick.Apis.Poe/Parser/Pseudo/PseudoParser.cs
@@ -1,5 +1,6 @@
 using Sidekick.Apis.Poe.Modifiers;
 using Sidekick.Apis.Poe.Parser.Pseudo.Definitions;
+using Sidekick.Common;
 using Sidekick.Common.Extensions;
 using Sidekick.Common.Game.Items;
 using Sidekick.Common.Settings;
@@ -21,6 +22,8 @@ public class PseudoParser
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);
         var game = leagueId.GetGameFromLeagueId();
 

--- a/src/Sidekick.Apis.Poe/Static/ItemStaticDataProvider.cs
+++ b/src/Sidekick.Apis.Poe/Static/ItemStaticDataProvider.cs
@@ -1,5 +1,6 @@
 using Sidekick.Apis.Poe.Clients;
 using Sidekick.Apis.Poe.Static.Models;
+using Sidekick.Common;
 using Sidekick.Common.Cache;
 using Sidekick.Common.Enums;
 using Sidekick.Common.Extensions;
@@ -27,6 +28,8 @@ public class ItemStaticDataProvider
     /// <inheritdoc/>
     public async Task Initialize()
     {
+        if (SidekickConfiguration.IsPoeApiDown) return;
+
         var leagueId = await settingsService.GetString(SettingKeys.LeagueId);
         var game = leagueId.GetGameFromLeagueId();
         var cacheKey = $"{game.GetValueAttribute()}_StaticData";

--- a/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
+++ b/src/Sidekick.Common.Blazor/Initialization/Initialization.razor.cs
@@ -112,7 +112,7 @@ public partial class Initialization
     private async Task Complete()
     {
         var redirectToHome = await SettingsService.GetBool(SettingKeys.OpenHomeOnLaunch);
-        if (redirectToHome)
+        if (redirectToHome || SidekickConfiguration.IsPoeApiDown)
         {
             NavigationManager.NavigateTo("/home");
         }

--- a/src/Sidekick.Common.Blazor/Settings/General/General.razor
+++ b/src/Sidekick.Common.Blazor/Settings/General/General.razor
@@ -7,7 +7,10 @@
     <FormFieldset Legend="@Resources["General_Settings"]">
         <LanguageParserEditor/>
         <UseInvariantForTradeResults/>
-        <LeagueIdEditor/>
+        @if (!SidekickConfiguration.IsPoeApiDown)
+        {
+            <LeagueIdEditor/>
+        }
         <InterfaceLanguageEditor/>
     </FormFieldset>
 

--- a/src/Sidekick.Common.Blazor/Setup/Setup.razor
+++ b/src/Sidekick.Common.Blazor/Setup/Setup.razor
@@ -125,7 +125,7 @@
             });
             Logger.LogError(e, "[Setup] Failed to initialize.");
             SidekickConfiguration.IsPoeApiDown = true;
-            NavigationManager.NavigateTo("/home");
+            NavigationManager.NavigateTo("/initialize");
         }
 
         await base.OnInitializedAsync();

--- a/src/Sidekick.Common.Blazor/Setup/Setup.razor
+++ b/src/Sidekick.Common.Blazor/Setup/Setup.razor
@@ -6,7 +6,6 @@
 @using Sidekick.Common.Platform
 @using Sidekick.Common.Settings
 @using Sidekick.Common.Blazor.Settings.General
-@using Sidekick.Common.Exceptions
 
 <LayoutSimple>
     <TopContent>
@@ -21,7 +20,7 @@
                 <AlertInfo>@Resources["New_League_Alert"]</AlertInfo>
             }
 
-            @if (HasError)
+            @if (FormInvalid)
             {
                 <AlertError>@Resources["Valid_Language_Alert"]</AlertError>
             }
@@ -69,6 +68,7 @@
 @inject IStringLocalizer<Setup> Resources
 @inject NavigationManager NavigationManager
 @inject ICurrentView CurrentView
+@inject ILogger<Setup> Logger
 
 @code {
 
@@ -76,7 +76,7 @@
 
     private bool NewLeagues { get; set; }
 
-    private bool HasError { get; set; }
+    private bool FormInvalid { get; set; }
 
     protected override async Task OnInitializedAsync()
     {
@@ -115,17 +115,6 @@
                 NavigationManager.NavigateTo("/initialize");
             }
         }
-        catch (SidekickException e)
-        {
-            CurrentView.Initialize(new ViewOptions()
-            {
-                Title = Resources["Setup"],
-                Width = 400,
-                Height = 360,
-            });
-            e.Actions = ExceptionActions.ExitApplication;
-            throw;
-        }
         catch (Exception e)
         {
             CurrentView.Initialize(new ViewOptions()
@@ -134,10 +123,9 @@
                 Width = 400,
                 Height = 360,
             });
-            throw new SidekickException(e.Message)
-            {
-                Actions = ExceptionActions.ExitApplication,
-            };
+            Logger.LogError(e, "[Setup] Failed to initialize.");
+            SidekickConfiguration.IsPoeApiDown = true;
+            NavigationManager.NavigateTo("/home");
         }
 
         await base.OnInitializedAsync();
@@ -154,7 +142,7 @@
         var leagues = await LeagueProvider.GetList(true);
         if (leagues.All(x => x.Id != leagueId))
         {
-            HasError = true;
+            FormInvalid = true;
             return;
         }
 

--- a/src/Sidekick.Common.Ui/App/AppResources.resx
+++ b/src/Sidekick.Common.Ui/App/AppResources.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -128,5 +128,8 @@
   </data>
   <data name="Home" xml:space="preserve">
       <value>Home</value>
+  </data>
+  <data name="PoeApiDown" xml:space="preserve">
+      <value>The trade website appears to be down. Restart Sidekick when the trade website is back online.</value>
   </data>
 </root>

--- a/src/Sidekick.Common.Ui/Errors/ConfigurationFlagError.razor
+++ b/src/Sidekick.Common.Ui/Errors/ConfigurationFlagError.razor
@@ -1,0 +1,28 @@
+﻿
+@if (SidekickConfiguration.IsPoeApiDown)
+{
+    <AlertError>@Resources["PoeApiDown"]</AlertError>
+}
+
+@inject IStringLocalizer<AppResources> Resources
+@implements IDisposable
+
+@code {
+
+    protected override void OnInitialized()
+    {
+        SidekickConfiguration.FlagChanged += SidekickConfigurationOnFlagChanged;
+        base.OnInitialized();
+    }
+
+    private void SidekickConfigurationOnFlagChanged()
+    {
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        SidekickConfiguration.FlagChanged -= SidekickConfigurationOnFlagChanged;
+    }
+
+}

--- a/src/Sidekick.Common.Ui/Layouts/LayoutSimple.razor
+++ b/src/Sidekick.Common.Ui/Layouts/LayoutSimple.razor
@@ -3,6 +3,7 @@
         @TopContent
     </div>
     <div class="grow overflow-y-auto overflow-x-hidden">
+        <ConfigurationFlagError />
         @ChildContent
     </div>
     <div class="dark:bg-stone-950">

--- a/src/Sidekick.Common.Ui/Layouts/LayoutTwoColumn.razor
+++ b/src/Sidekick.Common.Ui/Layouts/LayoutTwoColumn.razor
@@ -10,6 +10,7 @@
             </div>
         </div>
         <div class="h-full flex flex-col grow">
+            <ConfigurationFlagError />
             @if (HasChildContent)
             {
                 <div class="grow relative">

--- a/src/Sidekick.Common/SidekickConfiguration.cs
+++ b/src/Sidekick.Common/SidekickConfiguration.cs
@@ -7,6 +7,26 @@ namespace Sidekick.Common;
 /// </summary>
 public static class SidekickConfiguration
 {
+    private static bool isPoeApiDown;
+
+    /// <summary>
+    /// Occurs when a relevant flag or state within the application configuration changes.
+    /// </summary>
+    public static event Action? FlagChanged;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Path of Exile API is currently unavailable.
+    /// </summary>
+    public static bool IsPoeApiDown
+    {
+        get => isPoeApiDown;
+        set
+        {
+            isPoeApiDown = value;
+            FlagChanged?.Invoke();
+        }
+    }
+
     /// <summary>
     ///     Gets or sets a list of initializable services.
     /// </summary>


### PR DESCRIPTION
Fixes #393

Integrated a new mechanism to detect and handle POE API downtime with UI feedback through a `ConfigurationFlagError` component. Replaced exception-based error reporting with logging and navigation fallbacks, improving stability and maintainability.

![image](https://github.com/user-attachments/assets/90ebf0fe-f519-4cf7-9f49-1d5d42125de1)
