### PR TITLE
Use ManagePackageVersionsCentrally (CPM)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,60 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Blazor-ApexCharts" Version="5.1.0" />
+    <PackageVersion Include="bunit.web" Version="1.38.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="coverlet.msbuild" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="FuzzySharp" Version="2.0.2" />
+    <PackageVersion Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.100" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="MudBlazor" Version="8.3.0" />
+    <PackageVersion Include="PipeMethodCalls" Version="4.0.2" />
+    <PackageVersion Include="PipeMethodCalls.NetJson" Version="3.0.0" />
+    <PackageVersion Include="Romanization.NET" Version="0.9.5" />
+    <PackageVersion Include="Serilog" Version="4.2.0" />
+    <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageVersion Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageVersion Include="SharpHook" Version="5.3.9" />
+    <PackageVersion Include="System.Data.SQLite.Core" Version="1.0.119" />
+    <PackageVersion Include="System.IO" Version="4.3.0" />
+    <PackageVersion Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
+    <PackageVersion Include="System.Runtime.Handles" Version="4.3.0" />
+    <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.14" />
+    <PackageVersion Include="TextCopy" Version="6.2.1" />
+    <PackageVersion Include="Velopack" Version="0.0.1053" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageVersion>
+  </ItemGroup>
+</Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.14" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Localization" Version="8.0.14" />
     <PackageVersion Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.14" />
@@ -48,7 +48,7 @@
     <PackageVersion Include="System.Runtime.Handles" Version="4.3.0" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
     <PackageVersion Include="System.Text.Encoding.Extensions" Version="4.3.0" />
-    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.14" />
+    <PackageVersion Include="System.Threading.RateLimiting" Version="8.0.0" />
     <PackageVersion Include="TextCopy" Version="6.2.1" />
     <PackageVersion Include="Velopack" Version="0.0.1053" />
     <PackageVersion Include="xunit" Version="2.9.3" />

--- a/src/Sidekick.Apis.GitHub/Sidekick.Apis.GitHub.csproj
+++ b/src/Sidekick.Apis.GitHub/Sidekick.Apis.GitHub.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Apis.Poe/Sidekick.Apis.Poe.csproj
+++ b/src/Sidekick.Apis.Poe/Sidekick.Apis.Poe.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FuzzySharp" Version="2.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
-    <PackageReference Include="System.Threading.RateLimiting" Version="8.0.14" />
+    <PackageReference Include="FuzzySharp" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="System.Threading.RateLimiting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Apis.Poe2Scout/Sidekick.Apis.Poe2Scout.csproj
+++ b/src/Sidekick.Apis.Poe2Scout/Sidekick.Apis.Poe2Scout.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Apis.PoeNinja/Sidekick.Apis.PoeNinja.csproj
+++ b/src/Sidekick.Apis.PoeNinja/Sidekick.Apis.PoeNinja.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Apis.PoePriceInfo/Sidekick.Apis.PoePriceInfo.csproj
+++ b/src/Sidekick.Apis.PoePriceInfo/Sidekick.Apis.PoePriceInfo.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Apis.PoeWiki/Sidekick.Apis.PoeWiki.csproj
+++ b/src/Sidekick.Apis.PoeWiki/Sidekick.Apis.PoeWiki.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common.Blazor/Sidekick.Common.Blazor.csproj
+++ b/src/Sidekick.Common.Blazor/Sidekick.Common.Blazor.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.14" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common.Database/Sidekick.Common.Database.csproj
+++ b/src/Sidekick.Common.Database/Sidekick.Common.Database.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.14">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.14" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.14">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.119" />
+    <PackageReference Include="System.Data.SQLite.Core" />
   </ItemGroup>
 
 </Project>

--- a/src/Sidekick.Common.Interprocess/Sidekick.Common.Interprocess.csproj
+++ b/src/Sidekick.Common.Interprocess/Sidekick.Common.Interprocess.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="PipeMethodCalls" Version="4.0.2" />
-    <PackageReference Include="PipeMethodCalls.NetJson" Version="3.0.0" />
+    <PackageReference Include="PipeMethodCalls" />
+    <PackageReference Include="PipeMethodCalls.NetJson" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common.Platform/Sidekick.Common.Platform.csproj
+++ b/src/Sidekick.Common.Platform/Sidekick.Common.Platform.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SharpHook" Version="5.3.9" />
-    <PackageReference Include="TextCopy" Version="6.2.1" />
-    <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageReference Include="SharpHook" />
+    <PackageReference Include="TextCopy" />
+    <PackageReference Include="System.Security.Principal.Windows" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common.Ui/Sidekick.Common.Ui.csproj
+++ b/src/Sidekick.Common.Ui/Sidekick.Common.Ui.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="8.0.14" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.14" />
-    <PackageReference Include="MudBlazor" Version="8.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
+    <PackageReference Include="MudBlazor" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common.Updater/Sidekick.Common.Updater.csproj
+++ b/src/Sidekick.Common.Updater/Sidekick.Common.Updater.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Velopack" Version="0.0.1053" />
+      <PackageReference Include="Velopack" />
     </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Common/Sidekick.Common.csproj
+++ b/src/Sidekick.Common/Sidekick.Common.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.14" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Localization" Version="8.0.14" />
-    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" Version="8.0.14" />
-    <PackageReference Include="Romanization.NET" Version="0.9.5" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="System.IO" Version="4.3.0" />
-    <PackageReference Include="System.IO.FileSystem.Primitives" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Handles" Version="4.3.0" />
-    <PackageReference Include="System.Text.Encoding.Extensions" Version="4.3.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Localization" />
+    <PackageReference Include="Microsoft.Extensions.Localization.Abstractions" />
+    <PackageReference Include="Romanization.NET" />
+    <PackageReference Include="Serilog" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Extensions.Logging" />
+    <PackageReference Include="System.IO" />
+    <PackageReference Include="System.IO.FileSystem.Primitives" />
+    <PackageReference Include="System.Runtime.Handles" />
+    <PackageReference Include="System.Text.Encoding.Extensions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
+++ b/src/Sidekick.Modules.Trade/Sidekick.Modules.Trade.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor-ApexCharts" Version="5.1.0" />
+    <PackageReference Include="Blazor-ApexCharts" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Modules.Wealth/Sidekick.Modules.Wealth.csproj
+++ b/src/Sidekick.Modules.Wealth/Sidekick.Modules.Wealth.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazor-ApexCharts" Version="5.1.0" />
+    <PackageReference Include="Blazor-ApexCharts" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Sidekick.Wpf/Sidekick.Wpf.csproj
+++ b/src/Sidekick.Wpf/Sidekick.Wpf.csproj
@@ -50,8 +50,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" Version="2.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" Version="8.0.100" />
+    <PackageReference Include="Hardcodet.NotifyIcon.Wpf" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebView.Wpf" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Sidekick.Apis.Poe.Tests/Sidekick.Apis.Poe.Tests.csproj
+++ b/tests/Sidekick.Apis.Poe.Tests/Sidekick.Apis.Poe.Tests.csproj
@@ -9,19 +9,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="bunit.web" Version="1.38.5" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="bunit.web" />
+    <PackageReference Include="coverlet.collector" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
+    <PackageReference Include="coverlet.msbuild" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" >
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
So here's a neat thing; https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management

To easier maintain nuget and their versions in your project, you can centralize the versions to one file. This also ensures all projects are using the same version. :)

I also lowered the versions of:
System.Threading.RateLimiting 8.0.14 -> 8.0.0
Microsoft.Extensions.DependencyInjection.Abstractions 8.0.14 -> 8.0.2

To remove the warnings. 