### PR TITLE
Don't show Poe2Scout prices if the data isn't populated yet

### DIFF
--- a/src/Sidekick.Apis.Poe2Scout/Poe2ScoutClient.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Poe2ScoutClient.cs
@@ -40,7 +40,7 @@ public class Poe2ScoutClient(
 
         var prices = await GetPrices();
 
-        var price = prices.Where(x => x.CategoryApiId == category)
+        var price = prices.Where(x => x.CategoryApiId == category && x.Price != 0)
                           .FirstOrDefault(x => (x.Name == englishName || x.Name == englishType)
                                                || x.Type == englishType);
 

--- a/src/Sidekick.Modules.Trade/Components/Prices/Poe2ScoutComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Prices/Poe2ScoutComponent.razor
@@ -93,7 +93,7 @@ else if (Price != null)
         Price = await Client.GetPriceInfo(Item.Invariant?.Name, Item.Invariant?.Type, Item.Header.Category);
         NumberOfListings = Price?.PriceLogs?.LastOrDefault(x => x?.Quantity != null)?.Quantity;
 
-        if (Price?.PriceLogs != null)
+        if (Price?.PriceLogs?.Count > 1)
         {
             Series = Price.PriceLogs.Select((value, index) => new DataPoint
                 {


### PR DESCRIPTION
Fixes #629

Also don't show graph if only 1 data point.