### PR TITLE
Fixed the Poe2Scout price graph showing stats in reverse

### DIFF
--- a/src/Sidekick.Apis.Poe2Scout/Api/PriceLogs.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Api/PriceLogs.cs
@@ -4,4 +4,5 @@ public record Poe2ScoutPriceLog
 {
     public decimal? Price { get; init; }
     public int? Quantity { get; init; }
+    public DateTimeOffset? Time { get; init; }
 }

--- a/src/Sidekick.Apis.Poe2Scout/Poe2ScoutClient.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Poe2ScoutClient.cs
@@ -126,7 +126,7 @@ public class Poe2ScoutClient(
                                     : CultureInfo.CurrentCulture.TextInfo.ToTitleCase(x.CategoryApiId).GetEnumFromValue<Category>()
                                 : Category.Unknown,
                 Price = x.CurrentPrice,
-                PriceLogs = x.PriceLogs?.Where(x => x != null).ToList(),
+                PriceLogs = x.PriceLogs?.Where(x => x != null).OrderBy(x => x.Time).ToList(),
                 LastUpdated = DateTimeOffset.Now
             }).ToList();
         }


### PR DESCRIPTION
Also affects the number of listings shown since it was using the last element of the list.