### PR TITLE
Remove self-contained frameworks to reduce installer size

### DIFF
--- a/.github/workflows/windows-beta.yml
+++ b/.github/workflows/windows-beta.yml
@@ -95,7 +95,7 @@ jobs:
           Write-Output "Version: $version"
 
           dotnet publish src/Sidekick.Protocol/Sidekick.Protocol.csproj -p:PublishProfile=Build
-          dotnet publish src/Sidekick.Wpf/Sidekick.Wpf.csproj -c Release --self-contained true -r win-x64 -o ./Publish
+          dotnet publish src/Sidekick.Wpf/Sidekick.Wpf.csproj -c Release -r win-x64 -o ./Publish
 
       - name: Velopack
         shell: pwsh
@@ -113,5 +113,5 @@ jobs:
 
           dotnet tool install -g vpk
           vpk download github --repoUrl https://github.com/Sidekick-Poe/Sidekick --channel windows-beta
-          vpk pack --packId Sidekick --packVersion $version --packDir Publish --channel windows-beta --releaseNotes $releaseNotesPath
+          vpk pack --packId Sidekick --packVersion $version --packDir Publish --channel windows-beta --releaseNotes $releaseNotesPath --framework net8.0-x64-desktop,webview2
           vpk upload github --repoUrl https://github.com/Sidekick-Poe/Sidekick --channel windows-beta --pre --merge --releaseName "Sidekick v$version" --tag v$version --token ${{ github.token }}

--- a/.github/workflows/windows-stable.yml
+++ b/.github/workflows/windows-stable.yml
@@ -95,7 +95,7 @@ jobs:
           Write-Output "Version: $version"
 
           dotnet publish src/Sidekick.Protocol/Sidekick.Protocol.csproj -p:PublishProfile=Build
-          dotnet publish src/Sidekick.Wpf/Sidekick.Wpf.csproj -c Release --self-contained true -r win-x64 -o ./Publish
+          dotnet publish src/Sidekick.Wpf/Sidekick.Wpf.csproj -c Release -r win-x64 -o ./Publish
 
       - name: Velopack
         shell: pwsh
@@ -113,5 +113,5 @@ jobs:
 
           dotnet tool install -g vpk
           vpk download github --repoUrl https://github.com/Sidekick-Poe/Sidekick --channel windows-stable
-          vpk pack --packId Sidekick --packVersion $version --packDir Publish --channel windows-stable --releaseNotes $releaseNotesPath
+          vpk pack --packId Sidekick --packVersion $version --packDir Publish --channel windows-stable --releaseNotes $releaseNotesPath --framework net8.0-x64-desktop,webview2
           vpk upload github --repoUrl https://github.com/Sidekick-Poe/Sidekick --channel windows-stable --merge --releaseName "Sidekick v$version" --tag v$version --token ${{ github.token }}

--- a/src/Sidekick.Wpf/Sidekick.Wpf.csproj
+++ b/src/Sidekick.Wpf/Sidekick.Wpf.csproj
@@ -12,7 +12,7 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>favicon.ico</ApplicationIcon>
     <PublishSingleFile>false</PublishSingleFile>
-    <SelfContained>true</SelfContained>
+    <SelfContained>false</SelfContained>
     <PublishReadyToRun>true</PublishReadyToRun>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
     <AssemblyName>Sidekick</AssemblyName>


### PR DESCRIPTION
Closes #644.

Tested in a VM without Edge (forcefully removed with scripts) and without .NET Runtime:

![image](https://github.com/user-attachments/assets/0a54d1dc-ab83-4d48-a8a9-7f4189195b3d)

Though in order for the webview2 installer to run and finish, we need to remove the key starting with `F301` in `Computer\HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\`, as stated in our guide.
