### PR TITLE
Improve the feedback of the keybind editors

### DIFF
--- a/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
+++ b/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
@@ -107,8 +107,8 @@
                 }
                 else if (Keyboard.UsedKeybinds.Contains(key))
                 {
-                    IsDuplicated = true;
                     DuplicatedKey = key;
+                    IsDuplicated = true;
                 }
                 else
                 {

--- a/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
+++ b/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
@@ -1,8 +1,14 @@
+@using Sidekick.Common.Platform
+@using Sidekick.Common.Blazor.Settings
+@implements IDisposable
+
 <div>
-    <FormInput OnFocus="Focus"
+    <FormInput id="@Id"
+               OnFocus="Focus"
                OnBlur="Blur"
                Label="@Label"
                Value="@InputValue"
+               readonly="true"
                AdditionalClasses="cursor-default caret-transparent"
                spellcheck="false">
         <AdornmentContent>
@@ -13,20 +19,19 @@
     {
         <label class="mt-1 text-base font-medium text-amber-500 flex items-center flex-nowrap gap-2">
             <Icon Svg="@UiIcons.Warning" Size="@UiIconSize.Medium" />
-            <span>@Resources["Keybind_Already_In_Use"]</span>
+            <span>@string.Format(Resources["Keybind_Already_In_Use"], DuplicatedKey)</span>
         </label>
     }
 </div>
-@using Sidekick.Common.Platform
-@using Sidekick.Common.Blazor.Settings
-@implements IDisposable
 
 @inject IStringLocalizer<SettingsResources> Resources
 @inject IKeyboardProvider Keyboard
+@inject IJSRuntime JsRuntime
 
 @code {
-
     private static Guid? CurrentEditorId { get; set; }
+
+    private IJSObjectReference? Module { get; set; }
 
     private static event Action? CurrentEditorChanged;
 
@@ -44,6 +49,7 @@
     private bool Active => CurrentEditorId == Id;
 
     private bool IsDuplicated { get; set; } = false;
+    private string? DuplicatedKey { get; set; } = null;
 
     private string? InputValue
     {
@@ -63,6 +69,13 @@
         Keyboard.OnKeyDown += OnKeyDown;
         CurrentEditorChanged += StateHasChanged;
         base.OnInitialized();
+    }
+
+    private async Task RemoveFocusAsync()
+    {
+        Module = await JsRuntime.InvokeAsync<IJSObjectReference>("import",
+            "./_content/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor.js");
+        await Module.InvokeVoidAsync("removeFocus", Id);
     }
 
     public void Focus()
@@ -86,11 +99,16 @@
                 return;
             }
 
-            if (key != "Esc" && key != Value)
+            if (key != "Esc")
             {
-                if (Keyboard.UsedKeybinds.Contains(key))
+                if (key == Value)
+                {
+                    IsDuplicated = false;
+                }
+                else if (Keyboard.UsedKeybinds.Contains(key))
                 {
                     IsDuplicated = true;
+                    DuplicatedKey = key;
                 }
                 else
                 {
@@ -99,6 +117,7 @@
                 }
             }
 
+            await RemoveFocusAsync();
             CurrentEditorId = null;
             CurrentEditorChanged?.Invoke();
             StateHasChanged();

--- a/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor.js
+++ b/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor.js
@@ -1,0 +1,6 @@
+export const removeFocus = (elementId) => {
+    const element = document.getElementById(elementId);
+    if (element) {
+        element.blur();
+    }
+};

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
@@ -154,7 +154,7 @@
     <value>Autres configurations</value>
   </data>
   <data name="Keybind_Already_In_Use" xml:space="preserve">
-    <value>Raccourci déjà utilisé, veuillez en choisir un autre.</value>
+    <value>Raccourci "{0}" déjà utilisé, veuillez en choisir un autre.</value>
   </data>
   <data name="Key_Active" xml:space="preserve">
     <value>&lt;Appuyez sur une touche&gt;</value>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
@@ -154,7 +154,7 @@
     <value>Other Settings</value>
   </data>
   <data name="Keybind_Already_In_Use" xml:space="preserve">
-    <value>Keybind is already in use, please choose another one.</value>
+    <value>Keybind "{0}" is already in use, please choose another one.</value>
   </data>
   <data name="Key_Active" xml:space="preserve">
     <value>&lt;Press a key&gt;</value>


### PR DESCRIPTION
- Clear focus when changing value
- Clear validation if value is the same as the saved value
- Show which keybind is already used in validation