### PR TITLE
Enhance trade filters with a visual cue and a reset button

### DIFF
--- a/src/Sidekick.Common.Blazor/Settings/Chat/ChatCommandEditor.razor
+++ b/src/Sidekick.Common.Blazor/Settings/Chat/ChatCommandEditor.razor
@@ -4,7 +4,7 @@
 @foreach (var chatSetting in ChatSettings)
 {
     <div class="border border-solid dark:border-stone-800 p-3 mb-3">
-        <div class="grid grid-cols-12 gap-2">
+        <div class="grid grid-cols-12 gap-2 mb-3">
             <div class="col-span-6">
                 <FormInput Label="@Resources["Chat_Command"]" Value="@chatSetting.Command"
                     ValueChanged="(v) => CommandChanged(chatSetting, v)" />

--- a/src/Sidekick.Common.Blazor/Settings/General/UseInvariantForTradeResults.razor
+++ b/src/Sidekick.Common.Blazor/Settings/General/UseInvariantForTradeResults.razor
@@ -8,7 +8,7 @@
 
 <FormCheckbox Value="@UseInvariantTradeResults"
               ValueChanged="@UseInvariantTradeResultsChanged">
-    <div class="flex gap-2">
+    <div class="flex items-center gap-2">
         @Resources["UseInvariantForTradeResults"]
         <TooltipHint Text="@Resources["UseInvariantForTradeResultsTip"]" />
     </div>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
@@ -349,4 +349,7 @@
   <data name="PriceCheck_Market_Enable" xml:space="preserve">
     <value>Afficher les prix de poe.ninja (PoE1) et poe2scout.com (PoE2)</value>
   </data>
+  <data name="Clear_Filters" xml:space="preserve">
+    <value>Retirer les filtres</value>
+  </data>
 </root>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.ko.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.ko.resx
@@ -249,4 +249,7 @@
   <data name="Buyout_Price" xml:space="preserve">
     <value>가격</value>
   </data>
+  <data name="Clear_Filters" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
@@ -361,4 +361,7 @@
   <data name="PriceCheck_Market_Enable" xml:space="preserve">
     <value>Show prices from poe.ninja (PoE1) and poe2scout.com (PoE2)</value>
   </data>
+  <data name="Clear_Filters" xml:space="preserve">
+    <value>Clear filters</value>
+  </data>
 </root>

--- a/src/Sidekick.Common.Ui/Buttons/ButtonPrimary.razor
+++ b/src/Sidekick.Common.Ui/Buttons/ButtonPrimary.razor
@@ -1,9 +1,9 @@
-﻿<button type="button"
+<button type="button"
         disabled="@Disabled"
         @onclick="() => OnClick.InvokeAsync()"
         @onclick:preventDefault="true"
         @onclick:stopPropagation="true"
-        class="disabled:opacity-50 inline-flex items-center justify-center px-4 py-2 text-base font-medium tracking-wide text-white transition-colors duration-200 rounded-md bg-violet-700 hover:bg-violet-500 @UiClasses.FocusClasses">
+        class="disabled:opacity-50 inline-flex items-center justify-center px-4 py-2 text-base font-medium tracking-wide text-white transition-colors duration-200 rounded-md bg-violet-700 hover:enabled:bg-violet-500 @UiClasses.FocusClasses">
     @ChildContent
 </button>
 

--- a/src/Sidekick.Common.Ui/Icons/Icon.razor
+++ b/src/Sidekick.Common.Ui/Icons/Icon.razor
@@ -1,4 +1,15 @@
+<span class="fill-current inline-block @SizeClass @Class">
+    @((MarkupString)Svg)
+
+    @if (AddBadge)
+    {
+        <span class="absolute top-0 right-0 w-2 h-2 bg-red-700 rounded-full" />
+    }
+</span>
+
 @code {
+    [Parameter]
+    public bool AddBadge { get; set; }
 
     [Parameter]
     public required string Svg { get; set; }
@@ -17,5 +28,3 @@
     };
 
 }
-
-<span class="fill-current inline-block @SizeClass @Class">@((MarkupString)Svg)</span>

--- a/src/Sidekick.Common/Settings/DefaultSettings.cs
+++ b/src/Sidekick.Common/Settings/DefaultSettings.cs
@@ -48,6 +48,20 @@ public static class DefaultSettings
 
     public static string PriceCheckCurrencyMode => "item";
 
+    public static string? PriceCheckCurrency => null;
+
+    public static string? PriceCheckCurrencyPoE2 => null;
+
+    public static int PriceCheckItemCurrencyMin => 0;
+
+    public static int PriceCheckItemCurrencyMax => 0;
+
+    public static int PriceCheckItemCurrencyMinPoE2 => 0;
+
+    public static int PriceCheckItemCurrencyMaxPoE2 => 0;
+
+    public static string? PriceCheckItemListedAge => null;
+
     public static string PriceCheckItemClassFilter => DefaultItemClassFilter.BaseType.GetValueAttribute();
 
     public static double PriceCheckNormalizeValue => .1;

--- a/src/Sidekick.Common/Settings/ISettingsService.cs
+++ b/src/Sidekick.Common/Settings/ISettingsService.cs
@@ -60,12 +60,13 @@ public interface ISettingsService
         object? value);
 
     /// <summary>
-    /// Determines if a setting is different from its default value.
+    /// Determines if settings are different from their default value.
     /// </summary>
-    Task<bool> IsSettingModified(string key);
+    /// <returns>True if any setting is modified.</returns>
+    Task<bool> IsSettingModified(params string[] keys);
 
     /// <summary>
-    /// Restores a setting to its default value by removing the value from the database.
+    /// Restores settings to their default value by removing them.
     /// </summary>
-    Task DeleteSetting(string key);
+    Task DeleteSetting(params string[] keys);
 }

--- a/src/Sidekick.Common/Settings/ISettingsService.cs
+++ b/src/Sidekick.Common/Settings/ISettingsService.cs
@@ -58,4 +58,14 @@ public interface ISettingsService
     Task Set(
         string key,
         object? value);
+
+    /// <summary>
+    /// Determines if a setting is different from its default value.
+    /// </summary>
+    Task<bool> IsSettingModified(string key);
+
+    /// <summary>
+    /// Restores a setting to its default value by removing the value from the database.
+    /// </summary>
+    Task DeleteSetting(string key);
 }

--- a/src/Sidekick.Common/Settings/SettingsService.cs
+++ b/src/Sidekick.Common/Settings/SettingsService.cs
@@ -236,9 +236,11 @@ public class SettingsService(
 
         await using var dbContext = new SidekickDbContext(dbContextOptions);
 
+        var dbSettings = await dbContext.Settings.Where(x => keys.Contains(x.Key)).ToListAsync();
+
         foreach (var key in keys)
         {
-            var dbSetting = await dbContext.Settings.FirstOrDefaultAsync(x => x.Key == key);
+            var dbSetting = dbSettings.FirstOrDefault(x => x.Key == key);
 
             if (dbSetting == null)
             {
@@ -272,9 +274,11 @@ public class SettingsService(
         await using var dbContext = new SidekickDbContext(dbContextOptions);
         bool changed = false;
 
+        var dbSettings = await dbContext.Settings.Where(x => keys.Contains(x.Key)).ToListAsync();
+
         foreach (var key in keys)
         {
-            var dbSetting = await dbContext.Settings.FirstOrDefaultAsync(x => x.Key == key);
+            var dbSetting = dbSettings.FirstOrDefault(x => x.Key == key);
 
             if (dbSetting != null)
             {

--- a/src/Sidekick.Modules.Trade/Components/Filters/TradeFilters.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/TradeFilters.razor
@@ -11,21 +11,19 @@
         <PriceCheckStatusEditor />
         <PriceCheckItemCurrencyEditor />
         <FormFieldset Legend="@Resources["Item_Trade_Settings"]"
-        Dense="true">
+                      Dense="true">
             <PriceCheckItemMinMaxPriceEditor />
             <PriceCheckItemListedAgeEditor />
         </FormFieldset>
         <FormFieldset Legend="@Resources["Bulk_Trade_Settings"]"
-        Dense="true">
+                      Dense="true">
             <PriceCheckBulkMinimumStockEditor />
         </FormFieldset>
 
-        @if (AreSettingsModified)
-        {
-            <div class="flex justify-center mb-1">
-                <ButtonPrimary OnClick="ClearFilters">@Resources["Clear_Filters"]</ButtonPrimary>
-            </div>
-        }
+
+        <div class="flex justify-center mb-1">
+            <ButtonPrimary Disabled="!AreSettingsModified" OnClick="ClearFilters">@Resources["Clear_Filters"]</ButtonPrimary>
+        </div>
     </Popover>
 </div>
 
@@ -38,7 +36,7 @@
 
     private bool AreSettingsModified { get; set; }
 
-    private List<string> SettingKeysUsed { get; } = new()
+    private string[] SettingKeysUsed { get; } =
     {
         SettingKeys.PriceCheckStatus,
         SettingKeys.PriceCheckCurrency,
@@ -62,26 +60,14 @@
 
     private async void CheckIfSettingsAreModified()
     {
-        AreSettingsModified = false;
-
-        foreach (var settingKey in SettingKeysUsed)
-        {
-            if (await SettingsService.IsSettingModified(settingKey))
-            {
-                AreSettingsModified = true;
-                break;
-            }
-        }
+        AreSettingsModified = await SettingsService.IsSettingModified(SettingKeysUsed);
 
         await InvokeAsync(StateHasChanged);
     }
 
     private async void ClearFilters()
     {
-        foreach (var settingKey in SettingKeysUsed)
-        {
-            await SettingsService.DeleteSetting(settingKey);
-        }
+        await SettingsService.DeleteSetting(SettingKeysUsed);
 
         Visible = false;
 

--- a/src/Sidekick.Modules.Trade/Components/Filters/TradeFilters.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/TradeFilters.razor
@@ -1,30 +1,96 @@
-﻿@using Sidekick.Common.Blazor.Settings
+@using Sidekick.Common.Blazor.Settings
 @using Sidekick.Common.Ui.Popovers
+@using Sidekick.Common.Settings
 @using Sidekick.Modules.Trade.Settings
 
 <div class="relative">
     <ButtonIcon OnClick="() => Visible = !Visible">
-        <Icon Svg="@UiIcons.Adjustments" Size="@UiIconSize.Medium" />
+        <Icon Svg="@UiIcons.Adjustments" Size="@UiIconSize.Medium" AddBadge="AreSettingsModified" />
     </ButtonIcon>
     <Popover @bind-Visible="Visible">
-        <PriceCheckStatusEditor/>
-        <PriceCheckItemCurrencyEditor/>
+        <PriceCheckStatusEditor />
+        <PriceCheckItemCurrencyEditor />
         <FormFieldset Legend="@Resources["Item_Trade_Settings"]"
-                      Dense="true">
-            <PriceCheckItemMinMaxPriceEditor/>
-            <PriceCheckItemListedAgeEditor/>
+        Dense="true">
+            <PriceCheckItemMinMaxPriceEditor />
+            <PriceCheckItemListedAgeEditor />
         </FormFieldset>
         <FormFieldset Legend="@Resources["Bulk_Trade_Settings"]"
-                      Dense="true">
-            <PriceCheckBulkMinimumStockEditor/>
+        Dense="true">
+            <PriceCheckBulkMinimumStockEditor />
         </FormFieldset>
+
+        @if (AreSettingsModified)
+        {
+            <div class="flex justify-center mb-1">
+                <ButtonPrimary OnClick="ClearFilters">@Resources["Clear_Filters"]</ButtonPrimary>
+            </div>
+        }
     </Popover>
 </div>
 
 @inject IStringLocalizer<SettingsResources> Resources
+@inject ISettingsService SettingsService
 
 @code {
 
     private bool Visible { get; set; }
+
+    private bool AreSettingsModified { get; set; }
+
+    private List<string> SettingKeysUsed { get; } = new()
+    {
+        SettingKeys.PriceCheckStatus,
+        SettingKeys.PriceCheckCurrency,
+        SettingKeys.PriceCheckCurrencyPoE2,
+        SettingKeys.PriceCheckItemCurrencyMin,
+        SettingKeys.PriceCheckItemCurrencyMax,
+        SettingKeys.PriceCheckItemCurrencyMinPoE2,
+        SettingKeys.PriceCheckItemCurrencyMaxPoE2,
+        SettingKeys.PriceCheckItemListedAge,
+        SettingKeys.PriceCheckBulkMinimumStock
+    };
+
+    protected override async Task OnInitializedAsync()
+    {
+        SettingsService.OnSettingsChanged += CheckIfSettingsAreModified;
+
+        CheckIfSettingsAreModified();
+
+        await base.OnInitializedAsync();
+    }
+
+    private async void CheckIfSettingsAreModified()
+    {
+        AreSettingsModified = false;
+
+        foreach (var settingKey in SettingKeysUsed)
+        {
+            if (await SettingsService.IsSettingModified(settingKey))
+            {
+                AreSettingsModified = true;
+                break;
+            }
+        }
+
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async void ClearFilters()
+    {
+        foreach (var settingKey in SettingKeysUsed)
+        {
+            await SettingsService.DeleteSetting(settingKey);
+        }
+
+        Visible = false;
+
+        StateHasChanged();
+    }
+
+    public void Dispose()
+    {
+        SettingsService.OnSettingsChanged -= CheckIfSettingsAreModified;
+    }
 
 }


### PR DESCRIPTION
- Add badge parameter to Icon
- Add a badge to the trade filters icon if settings are not the default values 
![image](https://github.com/user-attachments/assets/128089bd-6bce-46cf-bee6-d090a0995e3b)

- Add a button in the trade filter settings to restore default values 
![image](https://github.com/user-attachments/assets/0c990c26-735d-4f8d-8e06-63880ca25341)


Unrelated:
- Align use invariant setting 
![image](https://github.com/user-attachments/assets/24186e97-28d3-4a78-8151-6571c1bd0917)