### PR TITLE
Fix Alt key not working with Regex Keybinds

### DIFF
--- a/src/Sidekick.Modules.RegexHotkeys/Keybinds/RegexHotkeyHandler.cs
+++ b/src/Sidekick.Modules.RegexHotkeys/Keybinds/RegexHotkeyHandler.cs
@@ -38,6 +38,7 @@ public class RegexHotkeyHandler(
 
         await clipboard.SetText(regexHotkey.Regex);
 
+        keyboard.ReleaseAltModifier();
         await keyboard.PressKey("Ctrl+F", "Ctrl+V");
 
         if (retainClipboard)


### PR DESCRIPTION
Fixes #716