### PR TITLE
Improve navigation with keyboard in the settings

### DIFF
--- a/src/Sidekick.Common.Blazor/Settings/About/About.razor
+++ b/src/Sidekick.Common.Blazor/Settings/About/About.razor
@@ -7,12 +7,24 @@
 <AppContainer>
     <FormFieldset Legend="@($"{Resources["Sidekick"]} - {Title}")">
         <div>
-            <div class="mb-3"><span class="text-lg underline text-blue-500 cursor-pointer" onclick="@(() => BrowserProvider.OpenSidekickWebsite())">@Resources["Official_Website"]</span></div>
-            <div class="mb-3"><span class="text-lg underline text-blue-500 cursor-pointer" onclick="@(() => BrowserProvider.OpenGitHubRepository())">@Resources["GitHub_Repository"]</span></div>
+            <div class="flex flex-col gap-2">
+                <div class="flex gap-2">
+                    <TextBase>@Resources["Official_Website"] - </TextBase>
+                    <ButtonLink OnClick="@(() => BrowserProvider.OpenUri(BrowserProvider.SidekickWebsite))">@BrowserProvider.SidekickWebsite</ButtonLink>
+                </div>
+                <div class="flex gap-2">
+                    <TextBase>@Resources["GitHub_Repository"] - </TextBase>
+                    <ButtonLink OnClick="@(() => BrowserProvider.OpenUri(BrowserProvider.GitHubRepository))">@BrowserProvider.GitHubRepository</ButtonLink>
+                </div>
+                <div class="flex gap-2">
+                    <TextBase>@Resources["Discord_Server"] - </TextBase>
+                    <ButtonLink OnClick="@(() => BrowserProvider.OpenUri(BrowserProvider.DiscordServer))">@BrowserProvider.DiscordServer</ButtonLink>
+                </div>
+            </div>
 
             <LayoutDivider />
 
-            <div class="mb-3"><ButtonPrimary OnClick="@(() => FolderProvider.OpenDataFolderPath())">@Resources["Open_Settings_Folder"]</ButtonPrimary></div>
+            <ButtonPrimary Class="mb-3 block!" OnClick="@(() => FolderProvider.OpenDataFolderPath())">@Resources["Open_Settings_Folder"]</ButtonPrimary>
             <code class="bg-stone-950 px-1 min-w-[8em]">@FolderProvider.GetDataFolderPath()</code>
         </div>
     </FormFieldset>

--- a/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
+++ b/src/Sidekick.Common.Blazor/Settings/Components/KeybindEditorInternal.razor
@@ -10,6 +10,7 @@
                Value="@InputValue"
                readonly="true"
                AdditionalClasses="cursor-default caret-transparent"
+               tabindex="-1"
                spellcheck="false">
         <AdornmentContent>
             <div class="flex ml-1 gap-1 align-center">

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.fr.resx
@@ -382,4 +382,7 @@
   <data name="Regex_Hint" xml:space="preserve">
     <value>Utilisez le caractère "|" pour séparer les modificateurs. Il n'est pas nécessaire de correspondre exactement au modificateur, et la distinction entre majuscules et minuscules est ignorée. Doit correspondre à la langue du jeu. Ex: "vie maximale|résistance|régénérée"</value>
   </data>
+  <data name="Discord_Server" xml:space="preserve">
+    <value>Serveur Discord</value>
+  </data>
 </root>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.ko.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.ko.resx
@@ -282,4 +282,7 @@
   <data name="Regex_Hint" xml:space="preserve">
     <value />
   </data>
+  <data name="Discord_Server" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
+++ b/src/Sidekick.Common.Blazor/Settings/SettingsResources.resx
@@ -394,4 +394,7 @@
   <data name="Regex_Hint" xml:space="preserve">
     <value>Use the "|" character to separate modifiers. The modifier does not need to match exactly, and differences between uppercase and lowercase are ignored. It should match the game's language. E.g. "maximum life|resistance|regen"</value>
   </data>
+  <data name="Discord_Server" xml:space="preserve">
+    <value>Discord server</value>
+  </data>
 </root>

--- a/src/Sidekick.Common.Ui/Buttons/ButtonLink.razor
+++ b/src/Sidekick.Common.Ui/Buttons/ButtonLink.razor
@@ -1,9 +1,9 @@
-﻿<button type="button"
+<button type="button"
         disabled="@Disabled"
         @onclick="() => OnClick.InvokeAsync()"
         @onclick:preventDefault="true"
         @onclick:stopPropagation="true"
-        class="inline-flex p-1 -m-1 text-nowrap items-center transition-all duration-200 rounded-md @UiClasses.FocusClasses disabled:opacity-50 font-medium justify-center bg-transparent border-transparent! text-inherit underline cursor-pointer hover:opacity-60">
+        class="inline-flex p-1 -m-1 text-nowrap items-center transition-all duration-200 rounded-md disabled:opacity-50 font-medium justify-center bg-transparent border-transparent! text-inherit underline cursor-pointer hover:opacity-60 @UiClasses.FocusClasses @Class">
     @ChildContent
 </button>
 
@@ -17,5 +17,8 @@
 
     [Parameter]
     public bool Disabled { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
 
 }

--- a/src/Sidekick.Common.Ui/Buttons/ButtonPrimary.razor
+++ b/src/Sidekick.Common.Ui/Buttons/ButtonPrimary.razor
@@ -3,7 +3,7 @@
         @onclick="() => OnClick.InvokeAsync()"
         @onclick:preventDefault="true"
         @onclick:stopPropagation="true"
-        class="disabled:opacity-50 inline-flex items-center justify-center px-4 py-2 text-base font-medium tracking-wide text-white transition-colors duration-200 rounded-md bg-violet-700 hover:enabled:bg-violet-500 @UiClasses.FocusClasses">
+        class="disabled:opacity-50 inline-flex items-center justify-center px-4 py-2 text-base font-medium tracking-wide text-white transition-colors duration-200 rounded-md bg-violet-700 hover:enabled:bg-violet-500 @UiClasses.FocusClasses @Class">
     @ChildContent
 </button>
 
@@ -17,5 +17,8 @@
 
     [Parameter]
     public bool Disabled { get; set; }
+
+    [Parameter]
+    public string? Class { get; set; }
 
 }

--- a/src/Sidekick.Common.Updater/Components/Update.razor
+++ b/src/Sidekick.Common.Updater/Components/Update.razor
@@ -196,7 +196,7 @@
 
     public void OpenWebsite()
     {
-        BrowserProvider.OpenSidekickWebsite();
+        BrowserProvider.OpenUri(BrowserProvider.SidekickWebsite);
     }
 
     public void Exit()

--- a/src/Sidekick.Common/Browser/BrowserProvider.cs
+++ b/src/Sidekick.Common/Browser/BrowserProvider.cs
@@ -6,6 +6,12 @@ namespace Sidekick.Common.Browser;
 
 public class BrowserProvider(ILogger<BrowserProvider> logger, IServiceProvider serviceProvider) : IBrowserProvider
 {
+    public Uri SidekickWebsite => new("https://sidekick-poe.github.io/");
+
+    public Uri GitHubRepository => new("https://github.com/Sidekick-Poe/Sidekick");
+
+    public Uri DiscordServer => new("https://discord.gg/R9HyCpV");
+
     public void OpenUri(Uri uri)
     {
         logger.LogInformation("[Browser] Opening: {uri}", uri.AbsoluteUri);
@@ -24,15 +30,5 @@ public class BrowserProvider(ILogger<BrowserProvider> logger, IServiceProvider s
             var dialogs = serviceProvider.GetService<ISidekickDialogs>();
             dialogs?.OpenOkModal("Failed to open URL: " + uri.AbsoluteUri);
         }
-    }
-
-    public void OpenSidekickWebsite()
-    {
-        OpenUri(new Uri("https://sidekick-poe.github.io/"));
-    }
-
-    public void OpenGitHubRepository()
-    {
-        OpenUri(new Uri("https://github.com/Sidekick-Poe/Sidekick"));
     }
 }

--- a/src/Sidekick.Common/Browser/IBrowserProvider.cs
+++ b/src/Sidekick.Common/Browser/IBrowserProvider.cs
@@ -3,18 +3,23 @@ namespace Sidekick.Common.Browser;
 public interface IBrowserProvider
 {
     /// <summary>
-    ///     Opens the specified Uri in a web browser
+    /// Opens the specified Uri in a web browser
     /// </summary>
     /// <param name="uri">The uri to open in a browser</param>
     void OpenUri(Uri uri);
 
     /// <summary>
-    ///     Opens the sidekick website in the user's browser.
+    /// The URL to the Sidekick website.
     /// </summary>
-    void OpenSidekickWebsite();
+    Uri SidekickWebsite { get; }
 
     /// <summary>
-    ///    Opens the Sidekick GitHub repository in the user's browser.
+    /// The URL to the Sidekick GitHub repository.
     /// </summary>
-    void OpenGitHubRepository();
+    Uri GitHubRepository { get; }
+
+    /// <summary>
+    /// The URL to the Sidekick Discord server.
+    /// </summary>
+    Uri DiscordServer { get; }
 }

--- a/src/Sidekick.Modules.RegexHotkeys/Settings/SettingsContent.razor
+++ b/src/Sidekick.Modules.RegexHotkeys/Settings/SettingsContent.razor
@@ -12,11 +12,11 @@
 
             <div class="my-3 flex gap-2">
                 <TextBase>@Resources["PathOfExile"] - </TextBase>
-                <ButtonLink OnClick="() => Browser.OpenUri(PathOfRegexWebsitePoE1)">@PathOfRegexWebsitePoE1.ToString()</ButtonLink>
+                <ButtonLink OnClick="() => Browser.OpenUri(PathOfRegexWebsitePoE1)">@PathOfRegexWebsitePoE1</ButtonLink>
             </div>
             <div class="flex gap-2">
                 <TextBase>@Resources["PathOfExile2"] - </TextBase>
-                <ButtonLink OnClick="() => Browser.OpenUri(PathOfRegexWebsitePoE2)">@PathOfRegexWebsitePoE2.ToString()</ButtonLink>
+                <ButtonLink OnClick="() => Browser.OpenUri(PathOfRegexWebsitePoE2)">@PathOfRegexWebsitePoE2</ButtonLink>
             </div>
         </div>
     </FormFieldset>

--- a/src/Sidekick.PhotinoBlazor/Services/PhotinoBlazorApplicationService.cs
+++ b/src/Sidekick.PhotinoBlazor/Services/PhotinoBlazorApplicationService.cs
@@ -77,7 +77,7 @@ public class PhotinoBlazorApplicationService
             },
             new(resources["Open_Website"])
             {
-                Click = (s, e) => browserProvider.OpenSidekickWebsite()
+                Click = (s, e) => browserProvider.OpenUri(browserProvider.SidekickWebsite)
             },
             new(resources["Exit"])
             {

--- a/src/Sidekick.Wpf/Services/WpfApplicationService.cs
+++ b/src/Sidekick.Wpf/Services/WpfApplicationService.cs
@@ -51,7 +51,7 @@ public class WpfApplicationService
         AddTrayItem(resources["Open_Website"],
                     () =>
                     {
-                        browserProvider.OpenSidekickWebsite();
+                        browserProvider.OpenUri(browserProvider.SidekickWebsite);
                         return Task.CompletedTask;
                     });
         AddTrayItem(resources["Exit"],


### PR DESCRIPTION
Closes #709

1. Made the About page closer to the UI of the RegexHotkeys page
2. Added the discord link
3. WPF will tab out of the page before looping back onto the first valid element, Photino loops correctly.