### PR TITLE
Allow to deselect desecrated modifiers to allow their explicit variants

### DIFF
--- a/src/Sidekick.Apis.Poe.Trade/Parser/Modifiers/ModifierMatch.cs
+++ b/src/Sidekick.Apis.Poe.Trade/Parser/Modifiers/ModifierMatch.cs
@@ -6,12 +6,12 @@ public class ModifierMatch
 (
     ParsingBlock block,
     IEnumerable<ParsingLine> lines,
-    IEnumerable<ModifierDefinition> patterns
+    IEnumerable<ModifierDefinition> definitions
 )
 {
     public ParsingBlock Block { get; } = block;
 
     public IEnumerable<ParsingLine> Lines { get; } = lines;
 
-    public IEnumerable<ModifierDefinition> Patterns { get; } = patterns;
+    public IEnumerable<ModifierDefinition> Definitions { get; } = definitions;
 }

--- a/src/Sidekick.Apis.Poe.Trade/Parser/Pseudo/PseudoDefinition.cs
+++ b/src/Sidekick.Apis.Poe.Trade/Parser/Pseudo/PseudoDefinition.cs
@@ -67,7 +67,8 @@ public abstract class PseudoDefinition
                 "enchant" => 4,
                 "fractured" => 5,
                 "veiled" => 6,
-                _ => 7,
+                "desecrated" => 7,
+                _ => 8,
             })
             .ThenBy(x => x.Text)
             .ToList();

--- a/src/Sidekick.Apis.Poe.Trade/Trade/Filters/ModifierFilter.cs
+++ b/src/Sidekick.Apis.Poe.Trade/Trade/Filters/ModifierFilter.cs
@@ -9,20 +9,16 @@ public class ModifierFilter : ITradeFilter
     {
         Line = line;
         Checked = line.Modifiers.FirstOrDefault()?.Category == ModifierCategory.Fractured;
-
-        if (HasMoreThanOneCategory && FirstCategory == ModifierCategory.Fractured)
-        {
-            ForceFirstCategory = true;
-        }
+        ForceCategory = HasMoreThanOneCategory && (Category == ModifierCategory.Fractured || Category == ModifierCategory.Desecrated);
     }
 
     public ModifierLine Line { get; }
 
-    public bool? @Checked { get; set; }
+    public bool? Checked { get; set; }
 
-    public bool ForceFirstCategory { get; set; }
+    public bool ForceCategory { get; set; }
 
-    public ModifierCategory FirstCategory => Line.Modifiers.FirstOrDefault()?.Category ?? ModifierCategory.Undefined;
+    public ModifierCategory Category => Line.Modifiers.FirstOrDefault()?.Category ?? ModifierCategory.Undefined;
 
     public bool HasMoreThanOneCategory => Line.Modifiers.GroupBy(x => x.Category).Count() > 1;
 

--- a/src/Sidekick.Apis.Poe.Trade/Trade/TradeSearchService.cs
+++ b/src/Sidekick.Apis.Poe.Trade/Trade/TradeSearchService.cs
@@ -252,14 +252,14 @@ public class TradeSearchService
                 continue;
             }
 
-            var modifiers = filter.Line.Modifiers;
-            if (filter.ForceFirstCategory)
+            var modifiers = filter.Line.Modifiers.ToList();
+            if (filter.ForceCategory)
             {
-                modifiers = modifiers.Where(x => x.Category == filter.FirstCategory).ToList();
+                modifiers = modifiers.Where(x => x.Category == filter.Category).ToList();
             }
             else if (modifiers.Any(x => x.Category == ModifierCategory.Explicit))
             {
-                modifiers = modifiers.Where(x => x.Category == ModifierCategory.Explicit).ToList();
+                modifiers = modifiers.Where(x => ModifierCategories.AllExplicitCategories.Contains(x.Category)).ToList();
             }
 
             foreach (var modifier in modifiers)

--- a/src/Sidekick.Common.Ui/App/AppSettings.razor
+++ b/src/Sidekick.Common.Ui/App/AppSettings.razor
@@ -1,5 +1,5 @@
-@using Microsoft.AspNetCore.Components.Sections
 @using Sidekick.Common.Ui.Localization
+@using Sidekick.Common.Ui.Sections
 
 <button type="button"
         @onclick="ToggleDrawer"
@@ -14,7 +14,7 @@
 <div class="relative">
     @if (Visible)
     {
-        <SectionContent SectionName="sidekick-overlay">
+        <BodySectionContent SectionName="app-settings">
             <div
                 class="dark:bg-stone-950 shadow-lg text-white fixed top-0 right-0 bottom-0 w-[450px] z-30 flex flex-col">
                 <div class="w-full flex justify-end">
@@ -49,7 +49,7 @@
                  @onclick:preventDefault="true"
                  @onclick:stopPropagation="true">
             </div>
-        </SectionContent>
+        </BodySectionContent>
     }
 </div>
 

--- a/src/Sidekick.Common.Ui/App/AppWrapper.razor
+++ b/src/Sidekick.Common.Ui/App/AppWrapper.razor
@@ -1,14 +1,14 @@
 @using Microsoft.AspNetCore.Components.Sections
 @using Sidekick.Common.Settings
+@using Sidekick.Common.Ui.Sections
 
 <ErrorFullScreenBoundary>
-    <div class="font-sans w-full h-[calc(var(--sidekick-vh))] overflow-y-auto overflow-x-hidden dark:bg-stone-900 text-white text-base [zoom:var(--sidekick-zoom)]">
+    <div
+        class="font-sans w-full h-[calc(var(--sidekick-vh))] overflow-y-auto overflow-x-hidden dark:bg-stone-900 text-white text-base [zoom:var(--sidekick-zoom)]">
         @ChildContent
     </div>
 
-    <div class="font-sans text-base">
-        <SectionOutlet SectionName="sidekick-overlay" />
-    </div>
+    <BodySectionOutlets/>
 </ErrorFullScreenBoundary>
 
 @inject IJSRuntime JsRuntime

--- a/src/Sidekick.Common.Ui/Forms/FormContentEditable.razor
+++ b/src/Sidekick.Common.Ui/Forms/FormContentEditable.razor
@@ -1,7 +1,7 @@
 ﻿@using System.Globalization
 
 <div id="@ElementId"
-     class="px-[2px] py-1 -my-1 border border-violet-800 bg-violet-300/10 min-w-6 text-center rounded-md whitespace-pre-wrap duration-200 @UiClasses.FocusClasses transition-colors hover:bg-violet-950 [&::selection]:bg-violet-700 [&::selection]:text-violet-200 text-violet-500 hover:text-violet-400 hover:border-violet-600"
+     class="p-[2px] border border-violet-800 bg-violet-300/10 min-w-6 text-center rounded-md whitespace-pre-wrap duration-200 @UiClasses.FocusClasses transition-colors hover:bg-violet-950 [&::selection]:bg-violet-700 [&::selection]:text-violet-200 text-violet-500 hover:text-violet-400 hover:border-violet-600"
      contenteditable="true">@Value</div>
 
 @inject IJSRuntime JsRuntime

--- a/src/Sidekick.Common.Ui/Poe/Items/ItemModifierCategoryChip.razor
+++ b/src/Sidekick.Common.Ui/Poe/Items/ItemModifierCategoryChip.razor
@@ -18,7 +18,7 @@
                 </svg>
             }
         }
-        @Category
+        <span class="leading-none">@Category</span>
         @if (ShowArrow)
         {
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4 fill-current">
@@ -58,6 +58,7 @@
         ModifierCategory.Scourge => "bg-[#ff6e25]",
         ModifierCategory.Veiled => "bg-[#545c63]",
         ModifierCategory.Crucible => "bg-[#ff7339]",
+        ModifierCategory.Desecrated => "bg-[#8e9e52]",
         _ => "bg-gray-600",
     };
 

--- a/src/Sidekick.Common.Ui/Sections/BodySectionContent.razor
+++ b/src/Sidekick.Common.Ui/Sections/BodySectionContent.razor
@@ -1,0 +1,28 @@
+﻿<SectionContent SectionName="@SectionName">
+    @ChildContent
+</SectionContent>
+
+@inject SectionService SectionService
+@using Microsoft.AspNetCore.Components.Sections
+@implements IDisposable
+
+@code {
+
+    [Parameter]
+    public required string SectionName { get; set; }
+
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
+    protected override void OnInitialized()
+    {
+        SectionService.AddBody(SectionName);
+        base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        SectionService.RemoveBody(SectionName);
+    }
+
+}

--- a/src/Sidekick.Common.Ui/Sections/BodySectionOutlets.razor
+++ b/src/Sidekick.Common.Ui/Sections/BodySectionOutlets.razor
@@ -1,0 +1,26 @@
+﻿<div class="font-sans text-base">
+    @foreach (var name in SectionService.BodySectionNames)
+    {
+        <SectionOutlet @key="@name"
+                       SectionName="@name"/>
+    }
+</div>
+
+@inject SectionService SectionService
+@using Microsoft.AspNetCore.Components.Sections
+@implements IDisposable
+
+@code {
+
+    protected override void OnInitialized()
+    {
+        SectionService.OnChanged += StateHasChanged;
+        base.OnInitialized();
+    }
+
+    public void Dispose()
+    {
+        SectionService.OnChanged -= StateHasChanged;
+    }
+
+}

--- a/src/Sidekick.Common.Ui/Sections/SectionService.cs
+++ b/src/Sidekick.Common.Ui/Sections/SectionService.cs
@@ -1,0 +1,20 @@
+﻿namespace Sidekick.Common.Ui.Sections;
+
+public class SectionService
+{
+    public event Action? OnChanged;
+
+    public List<string> BodySectionNames { get;  } = [];
+
+    public void AddBody(string name)
+    {
+        BodySectionNames.Add(name);
+        OnChanged?.Invoke();
+    }
+
+    public void RemoveBody(string name)
+    {
+        BodySectionNames.Remove(name);
+        OnChanged?.Invoke();
+    }
+}

--- a/src/Sidekick.Common.Ui/ServiceCollectionExtensions.cs
+++ b/src/Sidekick.Common.Ui/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Sidekick.Common.Ui.Dialogs;
+using Sidekick.Common.Ui.Sections;
 using Sidekick.Common.Ui.Views;
 
 namespace Sidekick.Common.Ui;
@@ -15,6 +16,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICurrentView, CurrentView>();
 
         services.AddSingleton<IViewPreferenceService, ViewPreferenceService>();
+        services.AddSingleton<SectionService>();
 
         services.AddSidekickModule(typeof(ConfirmationDialog).Assembly);
 

--- a/src/Sidekick.Common.Ui/Tooltips/Tooltip.razor
+++ b/src/Sidekick.Common.Ui/Tooltips/Tooltip.razor
@@ -14,18 +14,21 @@
     }
 </FlowbiteComponent>
 
-<div id="@Id" role="tooltip" class="bg-stone-950 p-2 max-w-60 rounded-lg border border-solid border-stone-800
-            absolute z-10 invisible transition-opacity duration-300 shadow-xs opacity-0 tooltip">
-    @if (TooltipContent is not null)
-    {
-        @TooltipContent
-    }
-    else
-    {
-        <div class="text-center text-sm leading-4">@Text</div>
-    }
-</div>
+<BodySectionContent SectionName="@Id">
+    <div id="@Id" role="tooltip" class="bg-stone-950 p-2 max-w-60 rounded-lg border border-solid border-stone-800
+            absolute z-10 invisible transition-opacity duration-300 shadow-xs opacity-0 tooltip text-white">
+        @if (TooltipContent is not null)
+        {
+            @TooltipContent
+        }
+        else
+        {
+            <div class="text-center text-sm leading-4">@Text</div>
+        }
+    </div>
+</BodySectionContent>
 
+@using Sidekick.Common.Ui.Sections
 @using Sidekick.Common.Enums
 
 @code {

--- a/src/Sidekick.Common/Game/Items/ModifierCategories.cs
+++ b/src/Sidekick.Common/Game/Items/ModifierCategories.cs
@@ -1,0 +1,16 @@
+namespace Sidekick.Common.Game.Items;
+
+public class ModifierCategories
+{
+    public static readonly List<ModifierCategory> AllExplicitCategories =
+    [
+        ModifierCategory.Explicit,
+        ModifierCategory.Fractured,
+        ModifierCategory.Desecrated,
+        ModifierCategory.Crafted,
+        ModifierCategory.Delve,
+        ModifierCategory.Scourge,
+        ModifierCategory.Veiled,
+        ModifierCategory.Crucible,
+    ];
+}

--- a/src/Sidekick.Common/Game/Items/ModifierCategory.cs
+++ b/src/Sidekick.Common/Game/Items/ModifierCategory.cs
@@ -1,22 +1,54 @@
+using Sidekick.Common.Enums;
+
 namespace Sidekick.Common.Game.Items;
 
 public enum ModifierCategory
 {
     Undefined = 0,
+
+    [EnumValue("crafted")]
     Crafted = 1,
+
+    [EnumValue("delve")]
     Delve = 2,
+
+    [EnumValue("enchant")]
     Enchant = 3,
+
+    [EnumValue("explicit")]
     Explicit = 4,
+
+    [EnumValue("fractured")]
     Fractured = 5,
+
+    [EnumValue("implicit")]
     Implicit = 6,
+
+    [EnumValue("monster")]
     Monster = 7,
+
+    [EnumValue("pseudo")]
     Pseudo = 8,
+
+    [EnumValue("scourge")]
     Scourge = 9,
+
+    [EnumValue("veiled")]
     Veiled = 10,
+
+    [EnumValue("crucible")]
     Crucible = 11,
+
+    [EnumValue("rune")]
     Rune = 12,
+
+    [EnumValue("sanctum")]
     Sanctum = 13,
+
+    [EnumValue("desecrated")]
     Desecrated = 14,
+
+    [EnumValue("skill")]
     Skill = 15,
 
     // Meta modifiers

--- a/src/Sidekick.Modules.Trade/Components/Filters/FilterRange.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/FilterRange.razor
@@ -1,11 +1,11 @@
 @using Sidekick.Common.Settings
 @using Sidekick.Modules.Trade.Localization;
 
-<div class="-mr-1 flex flex-nowrap items-center [&_.range~.range_[contenteditable]]:rounded-l-none! [&_.range_[contenteditable]]:rounded-r-none! [&_.range:last-child_[contenteditable]]:rounded-r-md!" id="@Id">
+<div class="flex flex-nowrap items-center [&_.range~.range_[contenteditable]]:rounded-l-none! [&_.range_[contenteditable]]:rounded-r-none! [&_.range:last-child_[contenteditable]]:rounded-r-md!" id="@Id">
     <Popover Trigger="PopoverTrigger.Hover">
         <PopoverAnchor>
-            <ButtonIcon OnClick="ToggleType" AdditionalClasses="mr-1">
-                <Icon Svg="@Icon" />
+            <ButtonIcon OnClick="ToggleType" AdditionalClasses="mr-[2px]">
+                <Icon Svg="@Icon" Class="!size-4 !min-h-4 !min-w-4" />
             </ButtonIcon>
         </PopoverAnchor>
         <PopoverContent>

--- a/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
+++ b/src/Sidekick.Modules.Trade/Components/Filters/ModifierFilterComponent.razor
@@ -17,40 +17,36 @@
 
         @if (EnchantmentOilNames?.Any() ?? false)
         {
-            <OilAnointment OilNames="EnchantmentOilNames" />
+            <OilAnointment OilNames="EnchantmentOilNames"/>
         }
 
-        <div class="flex flex-col items-end justify-between">
+        <div class="flex flex-col items-end justify-between gap-[2px] -mr-1">
             @if (Filter is
-                {
-                    Checked: true,
-                    HasMoreThanOneCategory: true,
-                    FirstCategory: not ModifierCategory.Explicit
-                })
+                     {
+                         Checked: true,
+                         HasMoreThanOneCategory: true,
+                         Category: not ModifierCategory.Explicit
+                     })
             {
                 <Tooltip Text="@Resources["ForceCategoryHint"]" Placement="TooltipPlacement.Right">
-                    <ChildContent>
-                        <ItemModifierCategoryChip Category="Filter.FirstCategory"
-                                                  Checked="Filter.ForceFirstCategory"
-                                                  ShowCheckbox="true"
-                                                  OnClick="() => Filter.ForceFirstCategory = !Filter.ForceFirstCategory" />
-                    </ChildContent>
+                    <ItemModifierCategoryChip Category="Filter.Category"
+                                              Checked="Filter.ForceCategory"
+                                              ShowCheckbox="true"
+                                              OnClick="() => Filter.ForceCategory = !Filter.ForceCategory"/>
                 </Tooltip>
-
-                <div class="h-[2px]"></div>
             }
 
             @if (Filter is
-                {
-                    Checked: true,
-                    Line:
-                    {
-                        HasValues: true
-                    }
-                })
+                     {
+                         Checked: true,
+                         Line:
+                         {
+                             HasValues: true
+                         }
+                     })
             {
                 <FilterRange @bind-Min="@Filter.Min" @bind-Max="@Filter.Max" Type="@Filter.FilterType"
-                             TypeChanged="(v) => Filter.ChangeFilterType(v)" />
+                             TypeChanged="(v) => Filter.ChangeFilterType(v)"/>
             }
         </div>
     </div>

--- a/src/Sidekick.Modules.Trade/Localization/TradeResources.fr.resx
+++ b/src/Sidekick.Modules.Trade/Localization/TradeResources.fr.resx
@@ -136,7 +136,7 @@
     <value>Min</value>
   </data>
   <data name="ForceCategoryHint" xml:space="preserve">
-    <value>Sélectionner cette case va limiter les recherches à cette catégorie. La désélectionner va permettre toutes les catégories dans les résultats (explicite, fabriqué, fracturé, etc.).</value>
+      <value>Sélectionner cette case va limiter les recherches à cette catégorie. La désélectionner va permettre toutes les catégories dans les résultats (explicite, fracturé, etc.).</value>
   </data>
   <data name="Layout_Cards_Maximized" xml:space="preserve">
     <value>Résultats détaillés</value>

--- a/src/Sidekick.Modules.Trade/Localization/TradeResources.resx
+++ b/src/Sidekick.Modules.Trade/Localization/TradeResources.resx
@@ -136,7 +136,7 @@
     <value>Min</value>
   </data>
   <data name="ForceCategoryHint" xml:space="preserve">
-    <value>Selecting this checkbox will force this specific category in the results. Unchecking allows for all modifier categories in the results (explicit, crafted, fractured, etc.).</value>
+      <value>Selecting this checkbox will force this specific category in the results. Unchecking allows for all modifier categories in the results (explicit, fractured, etc.).</value>
   </data>
   <data name="Layout_Cards_Maximized" xml:space="preserve">
     <value>Detailed results</value>

--- a/tests/Sidekick.Apis.Poe.Tests/Poe2/Parser/ArmourParsing.cs
+++ b/tests/Sidekick.Apis.Poe.Tests/Poe2/Parser/ArmourParsing.cs
@@ -127,4 +127,45 @@ Can only be equipped if you are wielding a Bow.
 
         Assert.Equal(8, actual.Properties.ItemLevel);
     }
+
+    [Fact]
+    public void ParseDesecratedBoots()
+    {
+        var actual = parser.ParseItem(
+            @"Item Class: Boots
+Rarity: Rare
+Victory Hoof
+Bastion Sabatons
+--------
+Quality: +20% (augmented)
+Armour: 149 (augmented)
+Evasion Rating: 118 (augmented)
+--------
+Requires: Level 59, 44 Str, 44 Dex
+--------
+Sockets: S 
+--------
+Item Level: 66
+--------
++14% to Fire Resistance (rune)
+--------
+25% increased Movement Speed
++83 to maximum Life
++20% to Fire Resistance
++22% to Cold Resistance
++34% to Lightning Resistance
++32 to Armour (desecrated)
++14 to Evasion Rating (desecrated)
+");
+
+        Assert.Equal(ItemClass.Boots, actual.Header.ItemClass);
+        Assert.Equal(Category.Armour, actual.Header.Category);
+        Assert.Equal(Rarity.Rare, actual.Header.Rarity);
+        Assert.Equal("Bastion Sabatons", actual.Header.ApiType);
+        Assert.Null(actual.Header.ApiName);
+
+        Assert.Equal(66, actual.Properties.ItemLevel);
+
+        actual.AssertHasModifier(ModifierCategory.Desecrated, "# to Armour", 32);
+    }
 }


### PR DESCRIPTION
# Example 1

<img width="325" height="79" alt="image" src="https://github.com/user-attachments/assets/8860b149-7603-48f9-ba98-a5aeccdf79f4" />
=>
<img width="333" height="169" alt="image" src="https://github.com/user-attachments/assets/df191d25-fa34-4d72-99f4-406f1e5540bb" />

===
# Example 2

<img width="327" height="66" alt="image" src="https://github.com/user-attachments/assets/e7bd0e07-0d9b-412e-a26a-cdd84345d8c3" />
<img width="739" height="282" alt="image" src="https://github.com/user-attachments/assets/e61ed1fd-ee5c-4358-8844-cee7bc0dc3fe" />
