### PR TITLE
Corrupted filter now defaults to 'Yes' or 'No' instead of Any.

### DIFF
--- a/src/Sidekick.Apis.Poe.Trade/Parser/Properties/Definitions/CorruptedProperty.cs
+++ b/src/Sidekick.Apis.Poe.Trade/Parser/Properties/Definitions/CorruptedProperty.cs
@@ -21,16 +21,10 @@ public class CorruptedProperty(IGameLanguageProvider gameLanguageProvider) : Pro
 
     public override Task<PropertyFilter?> GetFilter(Item item, double normalizeValue, FilterType filterType)
     {
-        bool? @checked = null;
-        if (item.Properties.Rarity == Rarity.Unique)
-        {
-            @checked = item.Properties.Corrupted;
-        }
-
         var filter = new TriStatePropertyFilter(this)
         {
             Text = gameLanguageProvider.Language.DescriptionCorrupted,
-            Checked = @checked,
+            Checked = item.Properties.Corrupted,
         };
         return Task.FromResult<PropertyFilter?>(filter);
     }


### PR DESCRIPTION
Fixes #868 

<img width="750" height="762" alt="image" src="https://github.com/user-attachments/assets/cb9e8825-048e-44f2-b924-dffec3b19a63" />

<img width="751" height="762" alt="image" src="https://github.com/user-attachments/assets/aaae9176-ab2c-468c-a04b-31f6b0c621ef" />
