### PR TITLE
Removed map wiki information on the item overlay due to the PoE 3.28 update.

### DIFF
--- a/src/Sidekick.Modules.Items/AreaInformation/AreaResult.razor
+++ b/src/Sidekick.Modules.Items/AreaInformation/AreaResult.razor
@@ -8,11 +8,13 @@
 <div class="h-2"></div>
 <AreaCheck/>
 
+@* Currently unused after changes made in Path of Exile 3.28. The update removed maps being tied to specific areas
 @if (Item.Game == GameType.PathOfExile1)
 {
     <ItemSeparator Rarity="Item.Properties.Rarity"/>
     <PoeWikiMapInfo Text="@Item.ApiInformation.InvariantText"/>
 }
+*@
 
 @inject IStringLocalizer<AreaResources> Resources
 

--- a/src/Sidekick.Modules.Items/AreaInformation/PoeWikiMapInfo.razor
+++ b/src/Sidekick.Modules.Items/AreaInformation/PoeWikiMapInfo.razor
@@ -2,6 +2,8 @@
 @using Sidekick.Apis.PoeWiki.Models
 @using Sidekick.Modules.Items.AreaInformation.Localization
 
+@* Currently unused after changes made in Path of Exile 3.28. The update removed maps being tied to specific areas *@
+
 @if (Loading)
 {
     <AppLoading/>


### PR DESCRIPTION
Fixes #998 