### PR TITLE
Restore Poe2Scout API compatibility

### DIFF
--- a/src/Sidekick.Apis.Poe2Scout/Categories/Models/ApiCategoriesResult.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Categories/Models/ApiCategoriesResult.cs
@@ -1,11 +1,8 @@
-﻿using System.Text.Json.Serialization;
-namespace Sidekick.Apis.Poe2Scout.Categories.Models;
+﻿namespace Sidekick.Apis.Poe2Scout.Categories.Models;
 
 public class ApiCategoriesResult
 {
-    [JsonPropertyName("unique_categories")]
     public List<ScoutCategory> UniqueCategories { get; set; } = [];
 
-    [JsonPropertyName("currency_categories")]
     public List<ScoutCategory> CurrencyCategories { get; set; } = [];
 }

--- a/src/Sidekick.Apis.Poe2Scout/Clients/ScoutClient.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Clients/ScoutClient.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
+using Sidekick.Common.Enums;
 using Sidekick.Common.Settings;
 using Sidekick.Data.Extensions;
 
@@ -22,6 +23,7 @@ public class ScoutClient
     private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        PropertyNameCaseInsensitive = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
         Converters =
         {
@@ -42,18 +44,34 @@ public class ScoutClient
     where TResponse : class
     {
         parameters ??= new();
+        var game = await settingsService.GetGame();
         var league = await settingsService.GetLeague();
-        parameters.TryAdd("league", league);
+        if (string.IsNullOrEmpty(league))
+        {
+            logger.LogError("[Poe2Scout] Could not fetch {Path}: no league is selected", path);
+            return null;
+        }
+
+        path = BuildPath(path, game.GetValueAttribute(), league, parameters);
 
         var query = string.Join("&",
-                                parameters.Select((x) => x.Key + "=" +
-                                                         Uri.EscapeDataString(x.Value?.ToString() ?? string.Empty)));
-        var url = new Uri($"{apiBaseUrl}{path}?{query}");
+                                parameters
+                                    .Where((x) => x.Value != null)
+                                    .Select((x) => x.Key + "=" + Uri.EscapeDataString(x.Value ?? string.Empty)));
+
+        var url = new Uri(query.Length > 0 ? $"{apiBaseUrl}{path}?{query}" : $"{apiBaseUrl}{path}");
 
         try
         {
             using var client = GetHttpClient();
             var response = await client.GetAsync(url);
+            if (!response.IsSuccessStatusCode)
+            {
+                var responseBody = await response.Content.ReadAsStringAsync();
+                logger.LogError("[Poe2Scout] Could not fetch {Url}. StatusCode={StatusCode}. Body={Body}", url, response.StatusCode, responseBody);
+                return null;
+            }
+
             var responseStream = await response.Content.ReadAsStreamAsync();
             var results = await JsonSerializer.DeserializeAsync<TResponse>(responseStream, JsonSerializerOptions);
             if (results != null) return results;
@@ -63,6 +81,59 @@ public class ScoutClient
         catch (Exception e)
         {
             logger.LogError(e, "[Poe2Scout] Could not fetch items from poe2scout.com");
+        }
+
+        return null;
+    }
+
+    private static string BuildPath(string path, string game, string league, Dictionary<string, string?> parameters)
+    {
+        if (path.Equals("items/categories", StringComparison.OrdinalIgnoreCase))
+        {
+            parameters.TryAdd("LeagueName", league);
+            return $"{game}/Items/Categories";
+        }
+
+        if (path.Equals("items", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{game}/Leagues/{Uri.EscapeDataString(league)}/Items";
+        }
+
+        if (path.StartsWith("items/", StringComparison.OrdinalIgnoreCase) &&
+            path.EndsWith("/history", StringComparison.OrdinalIgnoreCase))
+        {
+            parameters["LogCount"] = TakeParameter(parameters, "logCount", "LogCount") ?? "24";
+
+            var referenceCurrency = TakeParameter(parameters, "referenceCurrency", "ReferenceCurrency");
+            if (!string.IsNullOrEmpty(referenceCurrency))
+            {
+                parameters["ReferenceCurrency"] = referenceCurrency;
+            }
+
+            var itemId = path.Substring("items/".Length, path.Length - "items/".Length - "/history".Length);
+            return $"{game}/Leagues/{Uri.EscapeDataString(league)}/Items/{Uri.EscapeDataString(itemId)}/History";
+        }
+
+        if (path.Equals("currencyExchange/PairHistory", StringComparison.OrdinalIgnoreCase))
+        {
+            var currencyOneItemId = TakeParameter(parameters, "currencyOneItemId", "CurrencyOneItemId");
+            var currencyTwoItemId = TakeParameter(parameters, "currencyTwoItemId", "CurrencyTwoItemId");
+            parameters["Limit"] = TakeParameter(parameters, "limit", "Limit") ?? "24";
+
+            return $"{game}/Leagues/{Uri.EscapeDataString(league)}/Currencies/Pairs/{currencyOneItemId}/{currencyTwoItemId}/History";
+        }
+
+        return path;
+    }
+
+    private static string? TakeParameter(Dictionary<string, string?> parameters, params string[] keys)
+    {
+        foreach (var key in keys)
+        {
+            if (parameters.Remove(key, out var value))
+            {
+                return value;
+            }
         }
 
         return null;

--- a/src/Sidekick.Apis.Poe2Scout/History/Models/ApiHistoryResult.cs
+++ b/src/Sidekick.Apis.Poe2Scout/History/Models/ApiHistoryResult.cs
@@ -3,9 +3,8 @@ namespace Sidekick.Apis.Poe2Scout.History.Models;
 
 public class ApiHistoryResult
 {
-    [JsonPropertyName("has_more")]
     public bool HasMore { get; set; }
 
-    [JsonPropertyName("price_history")]
+    [JsonPropertyName("PriceHistory")]
     public List<ScoutHistoryLog> Logs { get; set; } = new();
 }


### PR DESCRIPTION
﻿## Summary

- Route existing Poe2Scout logical requests to the current API paths from the live OpenAPI schema.
- Support the current PascalCase response payloads for categories and item history.
- Log non-success Poe2Scout responses with the URL/status/body instead of failing opaquely.
- Guard against missing selected league before constructing league-scoped Poe2Scout URLs.

Fixes #1104.

## Why

Poe2Scout changed routes from the old `/api/items...` shape to realm/league-scoped paths such as `/api/poe2/Leagues/{LeagueName}/Items`. The old routes now return 404, so Sidekick's Poe2Scout-backed item/category/history panels cannot load.

This keeps the existing provider interfaces intact and limits the compatibility shim to `ScoutClient` plus the affected response models.

## Validation

Live endpoint smoke checks returned HTTP 200 for the current API shape:

- `https://poe2scout.com/api/poe2/Items/Categories?LeagueName=Fate%20of%20the%20Vaal`
- `https://poe2scout.com/api/poe2/Leagues/Fate%20of%20the%20Vaal/Items`
- `https://poe2scout.com/api/poe2/Leagues/Fate%20of%20the%20Vaal/Items/25/History?LogCount=24&ReferenceCurrency=exalted`
- `https://poe2scout.com/api/poe2/Leagues/Fate%20of%20the%20Vaal/Currencies/Pairs/287/290/History?Limit=24`

Local checks:

- `dotnet restore src\Sidekick.Apis.Poe2Scout\Sidekick.Apis.Poe2Scout.csproj`
- `dotnet build src\Sidekick.Apis.Poe2Scout\Sidekick.Apis.Poe2Scout.csproj --no-restore -warnaserror`
- `dotnet test --no-build --verbosity minimal`
