### PR TITLE
Update Korean trade API endpoint aligned with publisher change

### DIFF
--- a/src/Sidekick.Data/Languages/Implementations/GameLanguageKo.cs
+++ b/src/Sidekick.Data/Languages/Implementations/GameLanguageKo.cs
@@ -6,10 +6,10 @@ public class GameLanguageKo : IGameLanguage
     public string Code => "ko";
     public string Label => "Korean";
 
-    public string PoeTradeBaseUrl => "https://poe.game.daum.net/trade/";
-    public string PoeTradeApiBaseUrl => "https://poe.game.daum.net/api/trade/";
-    public string Poe2TradeBaseUrl => "https://poe.game.daum.net/trade2/";
-    public string Poe2TradeApiBaseUrl => "https://poe.game.daum.net/api/trade2/";
+    public string PoeTradeBaseUrl => "https://poe.kakaogames.com/trade/";
+    public string PoeTradeApiBaseUrl => "https://poe.kakaogames.com/api/trade/";
+    public string Poe2TradeBaseUrl => "https://poe.kakaogames.com/trade2/";
+    public string Poe2TradeApiBaseUrl => "https://poe.kakaogames.com/api/trade2/";
 
     public string RarityUnique => "고유";
     public string RarityRare => "희귀";


### PR DESCRIPTION
Recently, the publisher for the Korean version of PoE 1/2 changed, which also changed the base game URL. As a result, Sidekick is currently broken for Korean users.

This PR fixes #1141. I believe no further code changes are required since the fix is straightforward.

Thanks as always!
