### PR TITLE
Mouse‑wheel input on filters now updates the filter value without scrolling the interface, and clicking a filter value now selects the field as expected.

### DIFF
--- a/src/Sidekick.Common.Ui/Forms/FormNumber.razor
+++ b/src/Sidekick.Common.Ui/Forms/FormNumber.razor
@@ -40,8 +40,6 @@
 
     private IJSObjectReference? JsObject { get; set; }
 
-    private DotNetObjectReference<FormNumber>? Reference { get; set; }
-
     protected string ElementId { get; } = UiUtilities.GenerateId();
 
     protected string InternalValue { get; set; } = string.Empty;
@@ -58,8 +56,7 @@
         {
             try
             {
-                Reference = DotNetObjectReference.Create(this);
-                JsObject = await JsRuntime.InvokeAsync<IJSObjectReference>("sidekick.forms.numberInputWheel", ElementId, Reference);
+                JsObject = await JsRuntime.InvokeAsync<IJSObjectReference>("sidekick.forms.numberInputWheel", ElementId);
             }
             catch (Exception e)
             {
@@ -83,12 +80,11 @@
     }
 
     public async ValueTask DisposeAsync()
-    {        
+    {
         if (JsObject != null)
         {
             await JsObject.InvokeVoidAsync("dispose");
             await JsObject.DisposeAsync();
         }
-        Reference?.Dispose();
     }
 }

--- a/src/Sidekick.Common.Ui/Forms/FormNumber.razor
+++ b/src/Sidekick.Common.Ui/Forms/FormNumber.razor
@@ -3,14 +3,14 @@
 
     @if (!string.IsNullOrEmpty(Label))
     {
-        <label for="@Id"
+        <label for="@ElementId"
                class="block mb-1 text-base font-medium dark:text-zinc-300">
             @Label
         </label>
     }
 
     <div class="flex flex-nowrap gap-1">
-        <input id="@Id"
+        <input id="@ElementId"
                @attributes="InputAttributes"
                type="number"
                @onchange="OnChange"
@@ -19,6 +19,10 @@
     </div>
 
 </div>
+
+@inject IJSRuntime JsRuntime
+@inject ILogger<FormNumber> Logger
+@implements IAsyncDisposable
 
 @code {
 
@@ -34,7 +38,11 @@
     [Parameter(CaptureUnmatchedValues = true)]
     public Dictionary<string, object>? InputAttributes { get; set; }
 
-    protected string Id { get; } = UiUtilities.GenerateId();
+    private IJSObjectReference? JsObject { get; set; }
+
+    private DotNetObjectReference<FormNumber>? Reference { get; set; }
+
+    protected string ElementId { get; } = UiUtilities.GenerateId();
 
     protected string InternalValue { get; set; } = string.Empty;
 
@@ -42,6 +50,24 @@
     {
         InternalValue = Value?.ToString() ?? string.Empty;
         base.OnParametersSet();
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            try
+            {
+                Reference = DotNetObjectReference.Create(this);
+                JsObject = await JsRuntime.InvokeAsync<IJSObjectReference>("sidekick.forms.numberInputWheel", ElementId, Reference);
+            }
+            catch (Exception e)
+            {
+                Logger.LogError(e, "Failed to load javascript module.");
+            }
+        }
+
+        await base.OnAfterRenderAsync(firstRender);
     }
 
     protected async Task OnChange(ChangeEventArgs args)
@@ -56,4 +82,13 @@
         }
     }
 
+    public async ValueTask DisposeAsync()
+    {        
+        if (JsObject != null)
+        {
+            await JsObject.InvokeVoidAsync("dispose");
+            await JsObject.DisposeAsync();
+        }
+        Reference?.Dispose();
+    }
 }

--- a/src/Sidekick.Common.Ui/Forms/FormNumberInline.razor
+++ b/src/Sidekick.Common.Ui/Forms/FormNumberInline.razor
@@ -3,13 +3,13 @@
 <div class="flex flex-nowrap items-center gap-4">
     @if (!string.IsNullOrEmpty(Label))
     {
-        <label for="@Id"
+        <label for="@ElementId"
                class="block text-base font-medium dark:text-zinc-300 text-nowrap">
             @Label
         </label>
     }
     <div class="ml-auto">
-        <input id="@Id"
+        <input id="@ElementId"
                @attributes="InputAttributes"
                type="number"
                @onchange="OnChange"

--- a/src/Sidekick.Common.Ui/Scripts/esbuild.js
+++ b/src/Sidekick.Common.Ui/Scripts/esbuild.js
@@ -1,9 +1,9 @@
-﻿import { build } from 'esbuild';
+import { build } from 'esbuild';
 
 build({
     entryPoints: ['Scripts/index.js'],
     outfile: 'wwwroot/js/sidekick.js',
     bundle: true,
     minify: true,
-    sourcemap: true,
+    sourcemap: "inline",
 });

--- a/src/Sidekick.Common.Ui/Scripts/forms/contentEditable.js
+++ b/src/Sidekick.Common.Ui/Scripts/forms/contentEditable.js
@@ -1,4 +1,4 @@
-export default (elementId, dotNetRef) => {
+﻿export default (elementId, dotNetRef) => {
 
     const element = document.getElementById(elementId);
 

--- a/src/Sidekick.Common.Ui/Scripts/forms/contentEditable.js
+++ b/src/Sidekick.Common.Ui/Scripts/forms/contentEditable.js
@@ -1,4 +1,4 @@
-﻿export default (elementId, dotNetRef) => {
+export default (elementId, dotNetRef) => {
 
     const element = document.getElementById(elementId);
 
@@ -19,9 +19,9 @@
 
         const range = document.createRange();
         const selection = window.getSelection();
-        range.selectNodeContents(this); // Select all the content
-        selection.removeAllRanges();    // Clear any existing selection
-        selection.addRange(range);      // Apply the new range as the selection
+        range.selectNodeContents(element); // Select all the content
+        selection.removeAllRanges();       // Clear any existing selection
+        selection.addRange(range);         // Apply the new range as the selection
     };
     element.addEventListener("focus", focus);
 
@@ -45,10 +45,19 @@
         }
     }
 
+    /**
+     * Prevent scrolling the page when using the mouse wheel.
+     */
+    const wheel = (event) => {
+        event.preventDefault();
+    };
+    element.addEventListener("wheel", wheel, { passive: false });
+
     const dispose = () => {
         element.removeEventListener("input", input);
         element.removeEventListener("focus", focus);
         element.removeEventListener("blur", blur);
+        element.removeEventListener("wheel", wheel);
     }
 
     return {

--- a/src/Sidekick.Common.Ui/Scripts/forms/numberInputWheel.js
+++ b/src/Sidekick.Common.Ui/Scripts/forms/numberInputWheel.js
@@ -6,12 +6,22 @@ export default (elementId) => {
     const element = document.getElementById(elementId);
     if (!element) return;
 
-    element.addEventListener("wheel", (event) => {
+    var handler = (event) => {
         event.preventDefault();
 
         if (event.deltaY < 0)
             element.stepUp();
         else
             element.stepDown();
-    }, { passive: false });
+    };
+    element.addEventListener("wheel", handler, {passive: false});
+
+    const dispose = () => {
+        if (!element) return;
+        element.removeEventListener("wheel", handler);
+    }
+
+    return {
+        dispose,
+    };
 };

--- a/src/Sidekick.Common.Ui/Scripts/forms/numberInputWheel.js
+++ b/src/Sidekick.Common.Ui/Scripts/forms/numberInputWheel.js
@@ -1,0 +1,17 @@
+/**
+ * Prevent scrolling the page when using the mouse wheel.
+ * Allows the user to increment or decrement the value of a number input using the mouse wheel.
+ */
+export default (elementId) => {
+    const element = document.getElementById(elementId);
+    if (!element) return;
+
+    element.addEventListener("wheel", (event) => {
+        event.preventDefault();
+
+        if (event.deltaY < 0)
+            element.stepUp();
+        else
+            element.stepDown();
+    }, { passive: false });
+};

--- a/src/Sidekick.Common.Ui/Scripts/index.js
+++ b/src/Sidekick.Common.Ui/Scripts/index.js
@@ -5,6 +5,7 @@ import zoomHandler from "./app/zoomHandler";
 import contentEditable from "./forms/contentEditable";
 import removeFocus from "./forms/removeFocus.js";
 import setIndeterminate from "./forms/setIndeterminate.js";
+import numberInputWheel from "./forms/numberInputWheel.js";
 
 import modal from "./flowbite/modal";
 import popover from "./flowbite/popover";
@@ -25,5 +26,6 @@ window.sidekick = {
         contentEditable,
         removeFocus,
         setIndeterminate,
+        numberInputWheel,
     },
 };

--- a/src/Sidekick.Modules.Items/Tools/Chromatic/ChromaticCalculator.razor
+++ b/src/Sidekick.Modules.Items/Tools/Chromatic/ChromaticCalculator.razor
@@ -8,16 +8,20 @@
 
 <div class="grid grid-cols-4 gap-3 my-3">
     <FormNumber @bind-Value="NumberOfSockets"
-                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
+                min="0"
+                max="6"
                 Label="@Resources["Chromatic_Sockets"]"/>
     <FormNumber @bind-Value="RedSockets"
-                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
+                min="0"
+                max="6"
                 Label="@Resources["Chromatic_Red"]"/>
     <FormNumber @bind-Value="GreenSockets"
-                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
+                min="0"
+                max="6"
                 Label="@Resources["Chromatic_Green"]"/>
     <FormNumber @bind-Value="BlueSockets"
-                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
+                min="0"
+                max="6"
                 Label="@Resources["Chromatic_Blue"]"/>
 </div>
 

--- a/src/Sidekick.Modules.Items/Tools/Chromatic/ChromaticCalculator.razor
+++ b/src/Sidekick.Modules.Items/Tools/Chromatic/ChromaticCalculator.razor
@@ -1,4 +1,4 @@
-﻿@using Sidekick.Data.ItemClasses
+@using Sidekick.Data.ItemClasses
 @using Sidekick.Data.ItemDefinitions
 @using Sidekick.Data.Items
 @using Sidekick.Modules.Items.Components
@@ -8,12 +8,16 @@
 
 <div class="grid grid-cols-4 gap-3 my-3">
     <FormNumber @bind-Value="NumberOfSockets"
+                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
                 Label="@Resources["Chromatic_Sockets"]"/>
     <FormNumber @bind-Value="RedSockets"
+                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
                 Label="@Resources["Chromatic_Red"]"/>
     <FormNumber @bind-Value="GreenSockets"
+                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
                 Label="@Resources["Chromatic_Green"]"/>
     <FormNumber @bind-Value="BlueSockets"
+                InputAttributes="@(new() { { "min", 0 }, { "max", 6 } })"
                 Label="@Resources["Chromatic_Blue"]"/>
 </div>
 

--- a/src/Sidekick.Modules.Items/Tools/ToolTab.razor
+++ b/src/Sidekick.Modules.Items/Tools/ToolTab.razor
@@ -1,4 +1,4 @@
-﻿@using Sidekick.Modules.Items.Tools.Chromatic
+@using Sidekick.Modules.Items.Tools.Chromatic
 @using Sidekick.Modules.Items.Tools.Localization
 @using Sidekick.Data.Items
 @using Sidekick.Common.Ui.Tabs
@@ -16,7 +16,7 @@
     </ActivatorContent>
     <ChildContent>
         <div class="flex flex-col">
-            <ButtonLink Class="justify-start! p-3 gap-2" OnClick="OpenChromatic">Chromatic Calculator</ButtonLink>
+            <ButtonLink Class="justify-start! p-3 gap-2" OnClick="OpenChromatic">@Resources["ChromaticCalculator"]</ButtonLink>
         </div>
     </ChildContent>
 </Popover>

--- a/src/Sidekick.Modules.Items/Trade/Filters/FilterRange.razor
+++ b/src/Sidekick.Modules.Items/Trade/Filters/FilterRange.razor
@@ -44,7 +44,6 @@
 </Popover>
 
 @inject IStringLocalizer<TradeResources> Resources
-@inject IJSRuntime JsRuntime
 @inject ISettingsService SettingsService
 
 @code {
@@ -65,22 +64,6 @@
     public EventCallback<double?> MaxChanged { get; set; }
 
     private string Id { get; } = UiUtilities.GenerateId();
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender)
-        {
-            // Prevent the wheel event from scrolling.
-            var js = $@"
-                document.getElementById('{Id}')?.addEventListener('wheel', function(e) {{
-                    e.preventDefault();
-                }}, {{ passive: false }});
-            ";
-            await JsRuntime.InvokeVoidAsync("eval", js);
-        }
-
-        await base.OnAfterRenderAsync(firstRender);
-    }
 
     private async Task UpdateMinValue(double? value)
     {


### PR DESCRIPTION
Fixes #1120

- Fix sourcemaps not showing in devtools.
- Fix reference in contentEditable.
- Fix mouse wheel scroll in filters and number inputs.
- Limit ranges in chromatic calculator.
- Fix hardcoded string in chromatic calculator.