### PR TITLE
Fix UI deadlock cause on rate limiter

### DIFF
--- a/src/Sidekick.Apis.Common/Limiter/ServerSynchronizedRateLimiter.cs
+++ b/src/Sidekick.Apis.Common/Limiter/ServerSynchronizedRateLimiter.cs
@@ -176,13 +176,28 @@ public sealed class ServerSynchronizedRateLimiter : RateLimiter
 
     private void OnChangeSafe()
     {
-        try
+        // IMPORTANT: OnChangeSafe is always called while holding _lock (from
+        // RefreshWindow, AttemptAcquireCore, IdleDuration and the timer callback).
+        // Subscribers (e.g. the ApiStatusAndLimits Blazor component) marshal to the
+        // UI thread synchronously via Photino's InvokeAsync/PhotinoWindow.Invoke, and
+        // the UI render reads lock-protected state (CurrentHitCount/MaxHitCount).
+        // Invoking the event under _lock therefore deadlocks: the timer thread holds
+        // _lock and waits for the UI thread, while the UI thread waits for _lock.
+        // Dispatch the notification off the lock-holding thread so listeners never run
+        // while _lock is held.
+        var handler = OnChange;
+        if (handler == null) return;
+
+        Task.Run(() =>
         {
-            OnChange?.Invoke();
-        }
-        catch
-        {
-            // ignore listener exceptions
-        }
+            try
+            {
+                handler.Invoke();
+            }
+            catch
+            {
+                // ignore listener exceptions
+            }
+        });
     }
 }


### PR DESCRIPTION
# Fix UI deadlock: don't raise ServerSynchronizedRateLimiter.OnChange under _lock

## Problem
`ServerSynchronizedRateLimiter` raises its `OnChange` event from `OnChangeSafe()`,
which is always called while `_lock` is held (via `RefreshWindow` from the replenish
timer callback, `AttemptAcquireCore`, and `IdleDuration`).

The `ApiStatusAndLimits` Blazor component subscribes to `OnChange` and calls
`InvokeAsync(StateHasChanged)`. On Photino.Blazor this marshals to the UI thread
**synchronously** and blocks until the UI thread runs it. The UI thread, while
rendering that component, reads `CurrentHitCount`/`MaxHitCount`, which take `_lock`.

Deadlock:
- replenish-timer thread: holds `_lock`, waits for the UI thread
- UI thread: rendering, waits for `_lock`

This freezes the whole app (reproducible under sustained trade price-checking).
See the linked issue for full `dotnet-stack` backtraces of both threads.

## Fix
Invoke `OnChange` off the lock-holding thread so subscribers never execute while
`_lock` is held. No change to the locking logic, rate-limit math, or public API.

```diff
 private void OnChangeSafe()
 {
-    try
-    {
-        OnChange?.Invoke();
-    }
-    catch
-    {
-        // ignore listener exceptions
-    }
+    // OnChangeSafe is always called while holding _lock. Subscribers (the
+    // ApiStatusAndLimits Blazor component) marshal to the UI thread synchronously,
+    // and the UI render reads lock-protected state (CurrentHitCount/MaxHitCount).
+    // Raising the event under _lock deadlocks the replenish-timer thread against
+    // the UI thread. Dispatch off the lock-holding thread so listeners never run
+    // while _lock is held.
+    var handler = OnChange;
+    if (handler == null) return;
+
+    Task.Run(() =>
+    {
+        try { handler.Invoke(); }
+        catch { /* ignore listener exceptions */ }
+    });
 }
```

## Testing
Built `Sidekick.Apis.Common` and replaced the DLL in the 2026.6.5 AppImage. The freeze,
previously reproducible within minutes of price-checking, no longer occurs.

## Notes
Alternative (more invasive) fix would be to thread a "notify" flag out of
`RefreshWindow` and raise the event after releasing `_lock` at each call site; the
thread-hop above is the minimal, low-risk change. Either way the rule is: don't raise
events while holding a lock.
