### PR TITLE
Update to the new poe2scout api url

### DIFF
--- a/src/Sidekick.Apis.Poe2Scout/Clients/ScoutClient.cs
+++ b/src/Sidekick.Apis.Poe2Scout/Clients/ScoutClient.cs
@@ -18,7 +18,7 @@ public class ScoutClient
     ILogger<ScoutClient> logger
 ) : IScoutClient
 {
-    private static readonly Uri apiBaseUrl = new("https://poe2scout.com/api/");
+    private static readonly Uri apiBaseUrl = new("https://api.poe2scout.com/");
 
     private static JsonSerializerOptions JsonSerializerOptions { get; } = new()
     {


### PR DESCRIPTION
https://poe2scout.com/api/ no longer works. This change updates sidekick to use https://api.poe2scout.com/ instead